### PR TITLE
fix(security): clear high/moderate frontend dependency vulnerabilities

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -3,14 +3,17 @@
 ### English
 
 - **Mihomo core pinned to `v1.19.26`.** The build no longer resolves the upstream `latest` tag at prebuild time — the core version is now an explicit, reproducible pin (`META_VERSION_PINNED` in `scripts/prebuild.mjs`), bumpable in one line and overridable per-build via `MIHOMO_CORE_VERSION`. Updated the embedded sidecar from v1.19.25 to v1.19.26; config/runtime tests pass against the new core.
+- **Security: frontend dependency vulnerabilities cleared.** Bumped `react-router` to 7.17.0 and pinned patched `dompurify` (3.4.8, via override since `monaco-editor` bundles a vulnerable build) and `js-cookie` (3.0.8). `pnpm audit --prod` now reports no known vulnerabilities (was 3 high + 9 moderate).
 
 ### Русский
 
 - **Ядро Mihomo запинено на `v1.19.26`.** Сборка больше не резолвит апстрим-тег `latest` на этапе prebuild — версия ядра теперь явный, воспроизводимый пин (`META_VERSION_PINNED` в `scripts/prebuild.mjs`), меняется одной строкой и переопределяется на сборку через `MIHOMO_CORE_VERSION`. Встроенный sidecar обновлён с v1.19.25 до v1.19.26; тесты config/runtime проходят на новом ядре.
+- **Безопасность: устранены уязвимости фронт-зависимостей.** Поднят `react-router` до 7.17.0, запинены пропатченные `dompurify` (3.4.8, через override — `monaco-editor` тянет уязвимую сборку) и `js-cookie` (3.0.8). `pnpm audit --prod` теперь не находит уязвимостей (было 3 high + 9 moderate).
 
 ### 中文
 
 - **Mihomo 内核固定为 `v1.19.26`。** 构建不再在 prebuild 阶段解析上游 `latest` 标签——内核版本现为显式、可复现的固定值（`scripts/prebuild.mjs` 中的 `META_VERSION_PINNED`），可一行修改，并可通过 `MIHOMO_CORE_VERSION` 按次构建覆盖。内置 sidecar 从 v1.19.25 更新到 v1.19.26；config/runtime 测试在新内核上通过。
+- **安全：已清除前端依赖漏洞。** 将 `react-router` 升级到 7.17.0，并固定已修复的 `dompurify`（3.4.8，因 `monaco-editor` 捆绑了存在漏洞的版本，故用 override）与 `js-cookie`（3.0.8）。`pnpm audit --prod` 现已无已知漏洞（此前为 3 高 + 9 中）。
 
 ## Sloth Clash desktop `0.3.1` — 2026-04-30
 

--- a/package.json
+++ b/package.json
@@ -66,7 +66,7 @@
     "react-hook-form": "^7.72.0",
     "react-i18next": "17.0.4",
     "react-markdown": "10.1.0",
-    "react-router": "^7.13.1",
+    "react-router": "^7.17.0",
     "rehype-raw": "^7.0.0",
     "types-pac": "^1.0.3",
     "validator": "^13.15.26"
@@ -132,6 +132,10 @@
       "meta-json-schema",
       "sharp",
       "unrs-resolver"
-    ]
+    ],
+    "overrides": {
+      "dompurify@<3.3.2": "^3.4.8",
+      "js-cookie@<3.0.6": "^3.0.8"
+    }
   }
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -4,6 +4,10 @@ settings:
   autoInstallPeers: true
   excludeLinksFromLockfile: false
 
+overrides:
+  dompurify@<3.3.2: ^3.4.8
+  js-cookie@<3.0.6: ^3.0.8
+
 importers:
 
   .:
@@ -102,8 +106,8 @@ importers:
         specifier: 10.1.0
         version: 10.1.0(@types/react@19.2.14)(react@19.2.5)
       react-router:
-        specifier: ^7.13.1
-        version: 7.14.0(react-dom@19.2.5(react@19.2.5))(react@19.2.5)
+        specifier: ^7.17.0
+        version: 7.17.0(react-dom@19.2.5(react@19.2.5))(react@19.2.5)
       rehype-raw:
         specifier: ^7.0.0
         version: 7.0.0
@@ -2275,8 +2279,8 @@ packages:
   dom-walk@0.1.2:
     resolution: {integrity: sha512-6QvTW9mrGeIegrFXdtQi9pk7O/nSK6lSdXW2eqUspN5LWD7UTji2Fqw5V2YLjBpHEoU9Xl/eUWNpDeZvoyOv2w==}
 
-  dompurify@3.2.7:
-    resolution: {integrity: sha512-WhL/YuveyGXJaerVlMYGWhvQswa7myDG17P7Vu65EWC05o8vfeNbvNf4d/BOvH99+ZW+LlQsc1GDKMa1vNK6dw==}
+  dompurify@3.4.8:
+    resolution: {integrity: sha512-yb1cEmaOum7wFvOCSQxyfgVlv5D47Rc30iZWoMpbDIWTnJ6grDDQyu2KFJzB2k7u0pMuJcQ1zphH//fFnw2tjQ==}
 
   dot-case@3.0.4:
     resolution: {integrity: sha512-Kv5nKlh6yRrdrGvxeJ2e5y2eRUpkUosIW4A2AS38zwSz27zu7ufDwQPi5Jhs3XAlGNetl3bmnGhQsMtkKJnj3w==}
@@ -2847,9 +2851,8 @@ packages:
   jpeg-js@0.2.0:
     resolution: {integrity: sha512-Ni9PffhJtYtdD7VwxH6V2MnievekGfUefosGCHadog0/jAevRu6HPjYeMHbUemn0IPE8d4wGa8UsOGsX+iKy2g==}
 
-  js-cookie@3.0.5:
-    resolution: {integrity: sha512-cEiJEAEoIbWfCZYKWhVwFuvPX1gETRYPw6LlaTKoxD3s2AkXzkCjnp6h0V77ozyqj0jakteJ4YqDJT830+lVGw==}
-    engines: {node: '>=14'}
+  js-cookie@3.0.8:
+    resolution: {integrity: sha512-yeJd4aNAdYZQjaon2bpD/Gb0B/omw7HQOsynXXcOiWVCacbBcPlgn8S/d1X6blFSaHao7ozqtW7NZW19xpCtIw==}
 
   js-tokens@4.0.0:
     resolution: {integrity: sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==}
@@ -3438,8 +3441,8 @@ packages:
       '@types/react': '>=18'
       react: '>=18'
 
-  react-router@7.14.0:
-    resolution: {integrity: sha512-m/xR9N4LQLmAS0ZhkY2nkPA1N7gQ5TUVa5n8TgANuDTARbn1gt+zLPXEm7W0XDTbrQ2AJSJKhoa6yx1D8BcpxQ==}
+  react-router@7.17.0:
+    resolution: {integrity: sha512-FDELK7rTMlCHO5+reyXsPlmfr7N1F91lPHsWYfMEGQm/KQ+F4JFM8jGoeQDmDvdTs93Fw9aSilH+uKRb4/jXvQ==}
     engines: {node: '>=20.0.0'}
     peerDependencies:
       react: '>=18'
@@ -5742,7 +5745,7 @@ snapshots:
       '@types/js-cookie': 3.0.6
       dayjs: 1.11.20
       intersection-observer: 0.12.2
-      js-cookie: 3.0.5
+      js-cookie: 3.0.8
       lodash: 4.18.1
       react: 19.2.5
       react-dom: 19.2.5(react@19.2.5)
@@ -6028,7 +6031,7 @@ snapshots:
 
   dom-walk@0.1.2: {}
 
-  dompurify@3.2.7:
+  dompurify@3.4.8:
     optionalDependencies:
       '@types/trusted-types': 2.0.7
 
@@ -6729,7 +6732,7 @@ snapshots:
 
   jpeg-js@0.2.0: {}
 
-  js-cookie@3.0.5: {}
+  js-cookie@3.0.8: {}
 
   js-tokens@4.0.0: {}
 
@@ -7172,7 +7175,7 @@ snapshots:
 
   monaco-editor@0.55.1:
     dependencies:
-      dompurify: 3.2.7
+      dompurify: 3.4.8
       marked: 14.0.0
 
   monaco-languageserver-types@0.4.0:
@@ -7418,7 +7421,7 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  react-router@7.14.0(react-dom@19.2.5(react@19.2.5))(react@19.2.5):
+  react-router@7.17.0(react-dom@19.2.5(react@19.2.5))(react@19.2.5):
     dependencies:
       cookie: 1.1.1
       react: 19.2.5


### PR DESCRIPTION
Bump react-router to 7.17.0; pin patched dompurify (3.4.8) and js-cookie (3.0.8) via pnpm overrides (monaco-editor bundles a vulnerable dompurify with no newer release). pnpm audit --prod is now clean (was 3 high + 9 moderate). Closes audit F3.