### PR TITLE
feat(profiles): import local configs and proxy share links

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -4,16 +4,19 @@
 
 - **Mihomo core pinned to `v1.19.26`.** The build no longer resolves the upstream `latest` tag at prebuild time — the core version is now an explicit, reproducible pin (`META_VERSION_PINNED` in `scripts/prebuild.mjs`), bumpable in one line and overridable per-build via `MIHOMO_CORE_VERSION`. Updated the embedded sidecar from v1.19.25 to v1.19.26; config/runtime tests pass against the new core.
 - **Security: frontend dependency vulnerabilities cleared.** Bumped `react-router` to 7.17.0 and pinned patched `dompurify` (3.4.8, via override since `monaco-editor` bundles a vulnerable build) and `js-cookie` (3.0.8). `pnpm audit --prod` now reports no known vulnerabilities (was 3 high + 9 moderate).
+- **Import local configs & share links.** The Add-profile dialog gained a **Paste / File** mode: import a local mihomo/Clash `config.yaml`, or paste/load `vless://`, `vmess://`, `ss://`, `trojan://`, `hysteria2://`, `tuic://` links — a single link, a newline list, or a base64 subscription envelope — converted to a runnable config on import (with a live "Clash YAML / N share links" detection hint). Subscription URLs that return a share-link list now work too.
 
 ### Русский
 
 - **Ядро Mihomo запинено на `v1.19.26`.** Сборка больше не резолвит апстрим-тег `latest` на этапе prebuild — версия ядра теперь явный, воспроизводимый пин (`META_VERSION_PINNED` в `scripts/prebuild.mjs`), меняется одной строкой и переопределяется на сборку через `MIHOMO_CORE_VERSION`. Встроенный sidecar обновлён с v1.19.25 до v1.19.26; тесты config/runtime проходят на новом ядре.
 - **Безопасность: устранены уязвимости фронт-зависимостей.** Поднят `react-router` до 7.17.0, запинены пропатченные `dompurify` (3.4.8, через override — `monaco-editor` тянет уязвимую сборку) и `js-cookie` (3.0.8). `pnpm audit --prod` теперь не находит уязвимостей (было 3 high + 9 moderate).
+- **Импорт локальных конфигов и share-ссылок.** В диалоге добавления профиля появился режим **Paste / File**: можно импортировать локальный `config.yaml` (mihomo/Clash) или вставить/загрузить ссылки `vless://`, `vmess://`, `ss://`, `trojan://`, `hysteria2://`, `tuic://` — одну, списком по строкам или base64-обёрткой подписки — с конвертацией в рабочий конфиг при импорте (и живой подсказкой «Clash YAML / N ссылок»). Подписки, отдающие список ссылок, теперь тоже работают.
 
 ### 中文
 
 - **Mihomo 内核固定为 `v1.19.26`。** 构建不再在 prebuild 阶段解析上游 `latest` 标签——内核版本现为显式、可复现的固定值（`scripts/prebuild.mjs` 中的 `META_VERSION_PINNED`），可一行修改，并可通过 `MIHOMO_CORE_VERSION` 按次构建覆盖。内置 sidecar 从 v1.19.25 更新到 v1.19.26；config/runtime 测试在新内核上通过。
 - **安全：已清除前端依赖漏洞。** 将 `react-router` 升级到 7.17.0，并固定已修复的 `dompurify`（3.4.8，因 `monaco-editor` 捆绑了存在漏洞的版本，故用 override）与 `js-cookie`（3.0.8）。`pnpm audit --prod` 现已无已知漏洞（此前为 3 高 + 9 中）。
+- **导入本地配置与分享链接。** 添加配置文件对话框新增 **Paste / File** 模式：可导入本地 mihomo/Clash `config.yaml`，或粘贴/加载 `vless://`、`vmess://`、`ss://`、`trojan://`、`hysteria2://`、`tuic://` 链接——单条、按行列表或 base64 订阅封装——导入时转换为可运行配置（并实时提示「Clash YAML / N 条链接」）。返回链接列表的订阅 URL 现在也可用。
 
 ## Sloth Clash desktop `0.3.1` — 2026-04-30
 

--- a/apps/sloth-clash-desktop/advanced_tools.go
+++ b/apps/sloth-clash-desktop/advanced_tools.go
@@ -197,9 +197,21 @@ func (a *App) ReExtractBundledResources() error {
 func (a *App) ResetSubscriptionCache() error {
 	a.mu.RLock()
 	activeID := strings.TrimSpace(a.state.Profile.ActiveProfileID)
+	activeType := ""
+	for _, p := range a.profiles {
+		if p.ID == activeID {
+			activeType = p.Type
+			break
+		}
+	}
 	a.mu.RUnlock()
 	if activeID == "" {
 		return errors.New("no active profile")
+	}
+	// A local profile keeps its only copy of the config in the body cache —
+	// there is no URL to re-fetch from, so wiping it would destroy the profile.
+	if activeType == "local" {
+		return errors.New("local profiles have no remote cache to reset")
 	}
 	root, err := slothDataRoot()
 	if err != nil {

--- a/apps/sloth-clash-desktop/app.go
+++ b/apps/sloth-clash-desktop/app.go
@@ -732,6 +732,64 @@ func (a *App) ImportProfileFromURL(name string, rawURL string) (AppState, error)
 	return a.state, nil
 }
 
+// ImportProfileFromText creates a "local" profile from pasted or file-loaded
+// content: a Clash/mihomo YAML config, OR a list of share links (vless://,
+// vmess://, ss://, trojan://, hysteria2://, tuic://) — a single link, a
+// newline-separated list, or a base64 envelope. The content is validated, then
+// seeded into the profile's body cache so the normal pipeline turns it into a
+// runnable config on activation. Local profiles carry no URL and are never
+// auto-refreshed.
+func (a *App) ImportProfileFromText(name string, content string) (AppState, error) {
+	content = strings.TrimSpace(content)
+	if content == "" {
+		return a.GetAppState(), errors.New("config content is required")
+	}
+	// Validate up front: it must parse as a Clash doc, base64-Clash, or a
+	// supported share-link list. parseClashDocToMap covers all three.
+	if doc, perr := parseClashDocToMap([]byte(content)); perr != nil || len(doc) == 0 {
+		if perr != nil {
+			return a.GetAppState(), fmt.Errorf("not a valid config or supported share link: %w", perr)
+		}
+		return a.GetAppState(), errors.New("not a valid config or supported share link")
+	}
+
+	finalName := strings.TrimSpace(name)
+	if finalName == "" {
+		finalName = "Local config"
+	}
+
+	a.mu.Lock()
+	defer a.mu.Unlock()
+
+	id := "profile-" + time.Now().Format("20060102150405")
+	root, derr := slothDataRoot()
+	if derr != nil {
+		return a.state, derr
+	}
+	// Seed the per-profile body cache (the pipeline's cache-first source). For a
+	// local profile this is the durable home of the content — there is no URL to
+	// re-fetch from — so ResetSubscriptionCache refuses to wipe local caches.
+	writeSubscriptionBodyCache(filepath.Join(root, "runtime", id), []byte(content))
+
+	p := Profile{
+		ID:                id,
+		Name:              finalName,
+		Type:              "local",
+		LastUpdated:       time.Now().Unix(),
+		AutoUpdateEnabled: false,
+	}
+	a.profiles = append(a.profiles, p)
+	a.state.Profile.Profiles = a.profiles
+	if a.state.Profile.ActiveProfileID == "" {
+		a.state.Profile.ActiveProfileID = p.ID
+	}
+	a.state.UpdatedAt = time.Now().Unix()
+	if err := a.persistProfilesLocked(); err != nil {
+		return a.state, err
+	}
+	return a.state, nil
+}
+
 func (a *App) ActivateProfile(profileID string) (AppState, error) {
 	a.mu.Lock()
 	if profileID == "" {

--- a/apps/sloth-clash-desktop/frontend/src/App.css
+++ b/apps/sloth-clash-desktop/frontend/src/App.css
@@ -3257,6 +3257,47 @@
   margin-left: auto;
 }
 
+.modalFooterLeft {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: center;
+  gap: 10px;
+}
+
+.importModeTabs {
+  display: flex;
+  gap: 6px;
+  margin: 4px 0 14px;
+}
+
+.importModeTabs .btn {
+  flex: 1;
+}
+
+.importTextarea {
+  font-family: ui-monospace, SFMono-Regular, Menlo, Consolas, monospace;
+  font-size: 12.5px;
+  line-height: 1.5;
+  resize: vertical;
+  min-height: 160px;
+  white-space: pre;
+  overflow-wrap: normal;
+  overflow-x: auto;
+}
+
+.importDetect {
+  font-weight: 500;
+}
+
+.importDetect-yaml,
+.importDetect-links {
+  color: var(--accent);
+}
+
+.importDetect-unknown {
+  color: #d98c6a;
+}
+
 .btnModalSecondary {
   font-size: 13px;
   padding: 8px 14px;

--- a/apps/sloth-clash-desktop/frontend/src/App.tsx
+++ b/apps/sloth-clash-desktop/frontend/src/App.tsx
@@ -46,6 +46,7 @@ import {
   ActivateProfile,
   DeleteProfile,
   GetProfilePaths,
+  ImportProfileFromText,
   ImportProfileFromURL,
   ReadProfileConfig,
   RefreshProfileSubscription,
@@ -62,7 +63,10 @@ import { GetAppState, RefreshHomeInsight } from './api/state'
 import { GetSubscriptionDeviceIdentity } from './api/subscription'
 import { ApplyUpdate } from './api/update'
 import { DeleteProfileModal } from './components/DeleteProfileModal'
-import { ImportProfileModal } from './components/ImportProfileModal'
+import {
+  ImportProfileModal,
+  type ImportMode,
+} from './components/ImportProfileModal'
 import { ProfileContextMenu } from './components/ProfileContextMenu'
 import { ProfileEditInfoModal } from './components/ProfileEditInfoModal'
 import { ProfileFileModal } from './components/ProfileFileModal'
@@ -172,6 +176,8 @@ function App() {
     useState<main.SubscriptionDeviceIdentityPublic | null>(null)
   const [importName, setImportName] = useState('')
   const [importUrl, setImportUrl] = useState('')
+  const [importMode, setImportMode] = useState<ImportMode>('url')
+  const [importContent, setImportContent] = useState('')
   const [importModalOpen, setImportModalOpen] = useState(false)
   const [importModalReason, setImportModalReason] =
     useState<ImportModalReason>('manual')
@@ -1377,9 +1383,10 @@ function App() {
     setError('')
     try {
       const text = await navigator.clipboard.readText()
-      setImportUrl(text.trim())
+      if (importMode === 'paste') setImportContent(text)
+      else setImportUrl(text.trim())
     } catch {
-      setError('Could not read clipboard — paste the URL manually.')
+      setError('Could not read clipboard — paste manually.')
     }
   }
 
@@ -1388,11 +1395,16 @@ function App() {
     setImportBusy(true)
     try {
       const name = importName.trim()
-      await ImportProfileFromURL(name, importUrl.trim())
+      if (importMode === 'paste') {
+        await ImportProfileFromText(name, importContent.trim())
+      } else {
+        await ImportProfileFromURL(name, importUrl.trim())
+      }
       await refresh()
       dismissSpotlight()
       setImportUrl('')
       setImportName('')
+      setImportContent('')
       closeImportModal()
     } catch (e: any) {
       setError(String(e))
@@ -1924,11 +1936,15 @@ function App() {
         open={importModalOpen}
         title={importModalTitle()}
         blurb={importModalBlurb()}
+        mode={importMode}
         url={importUrl}
         name={importName}
+        content={importContent}
         busy={importBusy}
+        onModeChange={setImportMode}
         onUrlChange={setImportUrl}
         onNameChange={setImportName}
+        onContentChange={setImportContent}
         onPasteFromClipboard={() => pasteFromClipboard()}
         onClose={closeImportModal}
         onSubmit={() => performImportAndClose()}

--- a/apps/sloth-clash-desktop/frontend/src/api/profile.ts
+++ b/apps/sloth-clash-desktop/frontend/src/api/profile.ts
@@ -8,6 +8,7 @@ export {
   GetProfilePaths,
   GetProfileProxyGroupsBaseline,
   GetProfileRulesBaseline,
+  ImportProfileFromText,
   ImportProfileFromURL,
   ReadProfileConfig,
   RefreshProfileSubscription,

--- a/apps/sloth-clash-desktop/frontend/src/components/ImportProfileModal.tsx
+++ b/apps/sloth-clash-desktop/frontend/src/components/ImportProfileModal.tsx
@@ -1,12 +1,66 @@
+import { useRef } from 'react'
+
+export type ImportMode = 'url' | 'paste'
+
+const SCHEME_RE = /\b(?:vless|vmess|ss|trojan|hysteria2|hy2|tuic):\/\//gi
+
+function countLinks(s: string): number {
+  const m = s.match(SCHEME_RE)
+  return m ? m.length : 0
+}
+
+function looksLikeYaml(s: string): boolean {
+  return /^[ \t]*(proxies|proxy-groups|proxy-providers|rule-providers|rules|dns|tun)\s*:/m.test(
+    s,
+  )
+}
+
+function tryBase64(s: string): string {
+  try {
+    return atob(s.replace(/\s+/g, ''))
+  } catch {
+    return ''
+  }
+}
+
+type Detection = { kind: 'yaml' | 'links' | 'unknown'; label: string }
+
+function detect(raw: string): Detection | null {
+  const t = raw.trim()
+  if (!t) return null
+  if (looksLikeYaml(t)) return { kind: 'yaml', label: 'Clash YAML config' }
+  const n = countLinks(t)
+  if (n > 0)
+    return { kind: 'links', label: `${n} share link${n > 1 ? 's' : ''}` }
+  const dec = tryBase64(t)
+  if (dec) {
+    const m = countLinks(dec)
+    if (m > 0)
+      return {
+        kind: 'links',
+        label: `${m} share link${m > 1 ? 's' : ''} (base64)`,
+      }
+  }
+  return {
+    kind: 'unknown',
+    label:
+      'Unrecognized — expecting Clash YAML or vless:// / vmess:// / ss:// / trojan:// links',
+  }
+}
+
 export function ImportProfileModal({
   open,
   title,
   blurb,
+  mode,
   url,
   name,
+  content,
   busy,
+  onModeChange,
   onUrlChange,
   onNameChange,
+  onContentChange,
   onPasteFromClipboard,
   onClose,
   onSubmit,
@@ -14,16 +68,35 @@ export function ImportProfileModal({
   open: boolean
   title: string
   blurb: string
+  mode: ImportMode
   url: string
   name: string
+  content: string
   busy: boolean
+  onModeChange: (next: ImportMode) => void
   onUrlChange: (next: string) => void
   onNameChange: (next: string) => void
+  onContentChange: (next: string) => void
   onPasteFromClipboard: () => void
   onClose: () => void
   onSubmit: () => void
 }) {
+  const fileRef = useRef<HTMLInputElement>(null)
   if (!open) return null
+
+  const detection = mode === 'paste' ? detect(content) : null
+  const canSubmit =
+    !busy &&
+    (mode === 'url'
+      ? url.trim().length > 0
+      : content.trim().length > 0 && detection?.kind !== 'unknown')
+
+  const onFilePicked = async (file: File | undefined) => {
+    if (!file) return
+    const text = await file.text()
+    onContentChange(text)
+  }
+
   return (
     <div className="modalOverlay" role="presentation" onClick={onClose}>
       <div
@@ -38,15 +111,61 @@ export function ImportProfileModal({
         </h3>
         <p className="muted small">{blurb}</p>
 
-        <label className="field modalField">
-          <span className="fieldLab">Subscription URL</span>
-          <input
-            className="input"
-            value={url}
-            onChange={(e) => onUrlChange(e.target.value)}
-            placeholder="https://…"
-          />
-        </label>
+        <div className="segmentInset importModeTabs" role="tablist">
+          <button
+            type="button"
+            role="tab"
+            aria-selected={mode === 'url'}
+            className={mode === 'url' ? 'btn' : 'btn ghost'}
+            onClick={() => onModeChange('url')}
+          >
+            Subscription URL
+          </button>
+          <button
+            type="button"
+            role="tab"
+            aria-selected={mode === 'paste'}
+            className={mode === 'paste' ? 'btn' : 'btn ghost'}
+            onClick={() => onModeChange('paste')}
+          >
+            Paste / File
+          </button>
+        </div>
+
+        {mode === 'url' ? (
+          <label className="field modalField">
+            <span className="fieldLab">Subscription URL</span>
+            <input
+              className="input"
+              value={url}
+              onChange={(e) => onUrlChange(e.target.value)}
+              placeholder="https://…"
+            />
+          </label>
+        ) : (
+          <label className="field modalField">
+            <span className="fieldLab">
+              Config or share links
+              {detection ? (
+                <span className={`importDetect importDetect-${detection.kind}`}>
+                  {' '}
+                  · {detection.label}
+                </span>
+              ) : null}
+            </span>
+            <textarea
+              className="input importTextarea"
+              value={content}
+              rows={10}
+              spellCheck={false}
+              onChange={(e) => onContentChange(e.target.value)}
+              placeholder={
+                'Paste a mihomo/Clash config.yaml,\nor share links — one per line:\nvless://…\nvmess://…\ntrojan://…'
+              }
+            />
+          </label>
+        )}
+
         <label className="field modalField">
           <span className="fieldLab">
             Display name <span className="optional">(optional)</span>
@@ -55,18 +174,45 @@ export function ImportProfileModal({
             className="input"
             value={name}
             onChange={(e) => onNameChange(e.target.value)}
-            placeholder="Empty = use Profile-Title from server"
+            placeholder={
+              mode === 'url'
+                ? 'Empty = use Profile-Title from server'
+                : 'Empty = "Local config"'
+            }
           />
         </label>
 
         <div className="modalFooter">
-          <button
-            type="button"
-            className="btn btnModalSecondary"
-            onClick={onPasteFromClipboard}
-          >
-            Paste URL from clipboard
-          </button>
+          <div className="modalFooterLeft">
+            <button
+              type="button"
+              className="btn btnModalSecondary"
+              onClick={onPasteFromClipboard}
+            >
+              Paste from clipboard
+            </button>
+            {mode === 'paste' ? (
+              <>
+                <button
+                  type="button"
+                  className="btn btnModalSecondary"
+                  onClick={() => fileRef.current?.click()}
+                >
+                  Load from file…
+                </button>
+                <input
+                  ref={fileRef}
+                  type="file"
+                  accept=".yaml,.yml,.txt,.conf,text/*"
+                  style={{ display: 'none' }}
+                  onChange={(e) => {
+                    void onFilePicked(e.target.files?.[0])
+                    e.target.value = ''
+                  }}
+                />
+              </>
+            ) : null}
+          </div>
           <div className="modalFooterRight">
             <button
               type="button"
@@ -79,7 +225,7 @@ export function ImportProfileModal({
             <button
               type="button"
               className="btn primary"
-              disabled={busy || !url.trim()}
+              disabled={!canSubmit}
               onClick={onSubmit}
             >
               Import

--- a/apps/sloth-clash-desktop/sharelink/sharelink.go
+++ b/apps/sloth-clash-desktop/sharelink/sharelink.go
@@ -1,0 +1,643 @@
+// Package sharelink converts proxy "share links" (vless://, vmess://, ss://,
+// trojan://, hysteria2://, tuic://) into mihomo (Clash.Meta) proxy entries.
+//
+// It is intentionally self-contained (no mihomo Go dependency): each parser
+// maps a URI/encoded form to a map[string]any matching mihomo's `proxies:`
+// schema. Unknown/extra fields are ignored rather than failing, and an
+// unsupported scheme returns ErrUnsupportedScheme so callers can skip-and-report.
+package sharelink
+
+import (
+	"encoding/base64"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"net/url"
+	"strconv"
+	"strings"
+)
+
+// Proxy is a single mihomo proxy entry (marshals to a YAML mapping).
+type Proxy map[string]any
+
+// ErrUnsupportedScheme is returned by ParseLink for a scheme we don't handle.
+var ErrUnsupportedScheme = errors.New("unsupported share-link scheme")
+
+// SupportedSchemes lists the URI schemes ParseLink understands.
+var SupportedSchemes = []string{"vless", "vmess", "ss", "trojan", "hysteria2", "hy2", "tuic"}
+
+// HasSupportedScheme reports whether s begins with a supported share-link scheme.
+func HasSupportedScheme(s string) bool {
+	s = strings.TrimSpace(s)
+	for _, sc := range SupportedSchemes {
+		if strings.HasPrefix(s, sc+"://") {
+			return true
+		}
+	}
+	return false
+}
+
+// ParseLink converts a single share link into a mihomo Proxy.
+func ParseLink(link string) (Proxy, error) {
+	link = strings.TrimSpace(link)
+	scheme, _, found := strings.Cut(link, "://")
+	if !found {
+		return nil, fmt.Errorf("not a share link: %q", truncate(link, 24))
+	}
+	switch strings.ToLower(scheme) {
+	case "vless":
+		return parseVless(link)
+	case "vmess":
+		return parseVmess(link)
+	case "ss":
+		return parseSS(link)
+	case "trojan":
+		return parseTrojan(link)
+	case "hysteria2", "hy2":
+		return parseHysteria2(link)
+	case "tuic":
+		return parseTuic(link)
+	default:
+		return nil, fmt.Errorf("%w: %s", ErrUnsupportedScheme, scheme)
+	}
+}
+
+// ParseMany parses a block of text that may contain one share link per line.
+// It returns the successfully-parsed proxies and the raw lines it could not
+// convert (unsupported scheme or malformed). Blank lines and comments (#) are
+// ignored. Proxy names are de-duplicated so the result is a valid mihomo list.
+func ParseMany(text string) (proxies []Proxy, skipped []string) {
+	for _, raw := range strings.Split(normalizeNewlines(text), "\n") {
+		line := strings.TrimSpace(raw)
+		if line == "" || strings.HasPrefix(line, "//") || strings.HasPrefix(line, "#") {
+			continue
+		}
+		p, err := ParseLink(line)
+		if err != nil {
+			skipped = append(skipped, line)
+			continue
+		}
+		proxies = append(proxies, p)
+	}
+	dedupeNames(proxies)
+	return proxies, skipped
+}
+
+// LooksLikeShareLinks reports whether text (after an optional base64 unwrap)
+// contains at least one supported share link. It is the detection primitive
+// used to distinguish a V2Ray-style subscription from Clash YAML.
+func LooksLikeShareLinks(text string) bool {
+	for _, candidate := range []string{text, DecodeBase64Block(text)} {
+		for _, raw := range strings.Split(normalizeNewlines(candidate), "\n") {
+			if HasSupportedScheme(raw) {
+				return true
+			}
+		}
+	}
+	return false
+}
+
+// DecodeBase64Block returns the base64-decoded text if the whole input is a
+// single base64 blob (the V2Ray subscription envelope); otherwise it returns "".
+func DecodeBase64Block(text string) string {
+	t := strings.TrimSpace(text)
+	if t == "" || strings.ContainsAny(t, " \n\r\t") {
+		// A base64 envelope is one contiguous token; multi-line/space input is
+		// already decoded text.
+		// (still allow trailing newline trimmed above)
+	}
+	// Try standard and URL-safe, with and without padding.
+	for _, enc := range []*base64.Encoding{
+		base64.StdEncoding, base64.RawStdEncoding,
+		base64.URLEncoding, base64.RawURLEncoding,
+	} {
+		if dec, err := enc.DecodeString(strings.TrimSpace(t)); err == nil && len(dec) > 0 {
+			s := string(dec)
+			if HasSupportedScheme(firstNonEmptyLine(s)) || strings.Contains(s, "://") {
+				return s
+			}
+		}
+	}
+	return ""
+}
+
+// ---- per-scheme parsers ----
+
+func parseVless(link string) (Proxy, error) {
+	u, err := url.Parse(link)
+	if err != nil {
+		return nil, err
+	}
+	host, port, err := hostPort(u)
+	if err != nil {
+		return nil, err
+	}
+	uuid := u.User.Username()
+	if uuid == "" {
+		return nil, errors.New("vless: missing uuid")
+	}
+	q := u.Query()
+	p := Proxy{
+		"name":   nameFrom(u, host, port),
+		"type":   "vless",
+		"server": host,
+		"port":   port,
+		"uuid":   uuid,
+		"udp":    true,
+	}
+	network := orDefault(q.Get("type"), "tcp")
+	p["network"] = network
+	if flow := q.Get("flow"); flow != "" {
+		p["flow"] = flow
+	}
+	security := q.Get("security")
+	if security == "tls" || security == "reality" || q.Get("sni") != "" {
+		p["tls"] = true
+		if sni := q.Get("sni"); sni != "" {
+			p["servername"] = sni
+		}
+		if fp := q.Get("fp"); fp != "" {
+			p["client-fingerprint"] = fp
+		}
+		if alpn := q.Get("alpn"); alpn != "" {
+			p["alpn"] = splitCSV(alpn)
+		}
+	}
+	if security == "reality" {
+		ro := map[string]any{}
+		if pbk := q.Get("pbk"); pbk != "" {
+			ro["public-key"] = pbk
+		}
+		if sid := q.Get("sid"); sid != "" {
+			ro["short-id"] = sid
+		}
+		if len(ro) > 0 {
+			p["reality-opts"] = ro
+		}
+	}
+	applyTransport(p, network, q)
+	return p, nil
+}
+
+func parseVmess(link string) (Proxy, error) {
+	raw := strings.TrimPrefix(link, "vmess://")
+	dec, err := decodeFlexible(raw)
+	if err != nil {
+		return nil, fmt.Errorf("vmess: bad base64: %w", err)
+	}
+	var v map[string]any
+	if err := json.Unmarshal(dec, &v); err != nil {
+		return nil, fmt.Errorf("vmess: bad json: %w", err)
+	}
+	server := str(v["add"])
+	port := intish(v["port"])
+	if server == "" || port == 0 {
+		return nil, errors.New("vmess: missing server/port")
+	}
+	name := str(v["ps"])
+	if name == "" {
+		name = fmt.Sprintf("%s:%d", server, port)
+	}
+	network := orDefault(str(v["net"]), "tcp")
+	p := Proxy{
+		"name":    name,
+		"type":    "vmess",
+		"server":  server,
+		"port":    port,
+		"uuid":    str(v["id"]),
+		"alterId": intish(v["aid"]),
+		"cipher":  orDefault(str(v["scy"]), "auto"),
+		"network": network,
+		"udp":     true,
+	}
+	tls := str(v["tls"])
+	if tls == "tls" || str(v["sni"]) != "" {
+		p["tls"] = true
+		if sni := firstNonEmpty(str(v["sni"]), str(v["host"])); sni != "" {
+			p["servername"] = sni
+		}
+		if alpn := str(v["alpn"]); alpn != "" {
+			p["alpn"] = splitCSV(alpn)
+		}
+	}
+	switch network {
+	case "ws":
+		ws := map[string]any{}
+		if path := str(v["path"]); path != "" {
+			ws["path"] = path
+		}
+		if host := str(v["host"]); host != "" {
+			ws["headers"] = map[string]any{"Host": host}
+		}
+		if len(ws) > 0 {
+			p["ws-opts"] = ws
+		}
+	case "grpc":
+		if sn := firstNonEmpty(str(v["path"]), str(v["serviceName"])); sn != "" {
+			p["grpc-opts"] = map[string]any{"grpc-service-name": sn}
+		}
+	}
+	return p, nil
+}
+
+func parseSS(link string) (Proxy, error) {
+	rest := strings.TrimPrefix(link, "ss://")
+	// Split off #fragment (name) first.
+	frag := ""
+	if i := strings.IndexByte(rest, '#'); i >= 0 {
+		frag = rest[i+1:]
+		rest = rest[:i]
+	}
+	var method, password, host string
+	var port int
+	if at := strings.LastIndexByte(rest, '@'); at >= 0 {
+		// SIP002: ss://base64(method:password)@host:port[/?plugin=...]
+		userinfo := rest[:at]
+		hostpart := rest[at+1:]
+		mp, err := decodeFlexible(userinfo)
+		if err != nil {
+			// userinfo may be plain method:password (rare)
+			mp = []byte(userinfo)
+		}
+		method, password = splitColon(string(mp))
+		hp, _, _ := strings.Cut(hostpart, "/")
+		hp, _, _ = strings.Cut(hp, "?")
+		host, port = splitHostPort(hp)
+	} else {
+		// Legacy: ss://base64(method:password@host:port)
+		dec, err := decodeFlexible(rest)
+		if err != nil {
+			return nil, fmt.Errorf("ss: bad base64: %w", err)
+		}
+		body := string(dec)
+		creds, hp := "", ""
+		if at := strings.LastIndexByte(body, '@'); at >= 0 {
+			creds, hp = body[:at], body[at+1:]
+		} else {
+			return nil, errors.New("ss: malformed legacy link")
+		}
+		method, password = splitColon(creds)
+		host, port = splitHostPort(hp)
+	}
+	if host == "" || port == 0 || method == "" {
+		return nil, errors.New("ss: missing cipher/server/port")
+	}
+	name := decodeFragment(frag)
+	if name == "" {
+		name = fmt.Sprintf("%s:%d", host, port)
+	}
+	p := Proxy{
+		"name":     name,
+		"type":     "ss",
+		"server":   host,
+		"port":     port,
+		"cipher":   method,
+		"password": password,
+		"udp":      true,
+	}
+	// plugin (?plugin=obfs-local;obfs=http;obfs-host=...)
+	if i := strings.IndexByte(link, '?'); i >= 0 {
+		if q, err := url.ParseQuery(stripFragment(link[i+1:])); err == nil {
+			if plug := q.Get("plugin"); plug != "" {
+				applySSPlugin(p, plug)
+			}
+		}
+	}
+	return p, nil
+}
+
+func parseTrojan(link string) (Proxy, error) {
+	u, err := url.Parse(link)
+	if err != nil {
+		return nil, err
+	}
+	host, port, err := hostPort(u)
+	if err != nil {
+		return nil, err
+	}
+	password := u.User.Username()
+	if password == "" {
+		return nil, errors.New("trojan: missing password")
+	}
+	q := u.Query()
+	p := Proxy{
+		"name":     nameFrom(u, host, port),
+		"type":     "trojan",
+		"server":   host,
+		"port":     port,
+		"password": password,
+		"udp":      true,
+	}
+	if sni := firstNonEmpty(q.Get("sni"), q.Get("peer")); sni != "" {
+		p["sni"] = sni
+	}
+	if q.Get("allowInsecure") == "1" || q.Get("insecure") == "1" {
+		p["skip-cert-verify"] = true
+	}
+	if alpn := q.Get("alpn"); alpn != "" {
+		p["alpn"] = splitCSV(alpn)
+	}
+	network := q.Get("type")
+	if network != "" && network != "tcp" {
+		p["network"] = network
+		applyTransport(p, network, q)
+	}
+	return p, nil
+}
+
+func parseHysteria2(link string) (Proxy, error) {
+	u, err := url.Parse(link)
+	if err != nil {
+		return nil, err
+	}
+	host, port, err := hostPort(u)
+	if err != nil {
+		return nil, err
+	}
+	q := u.Query()
+	// auth may be in userinfo (password) or as ?auth=
+	password := u.User.Username()
+	if pw, ok := u.User.Password(); ok && pw != "" {
+		password = password + ":" + pw
+	}
+	if password == "" {
+		password = q.Get("auth")
+	}
+	p := Proxy{
+		"name":     nameFrom(u, host, port),
+		"type":     "hysteria2",
+		"server":   host,
+		"port":     port,
+		"password": password,
+	}
+	if sni := q.Get("sni"); sni != "" {
+		p["sni"] = sni
+	}
+	if q.Get("insecure") == "1" {
+		p["skip-cert-verify"] = true
+	}
+	if obfs := q.Get("obfs"); obfs != "" {
+		p["obfs"] = obfs
+		if op := q.Get("obfs-password"); op != "" {
+			p["obfs-password"] = op
+		}
+	}
+	if alpn := q.Get("alpn"); alpn != "" {
+		p["alpn"] = splitCSV(alpn)
+	}
+	return p, nil
+}
+
+func parseTuic(link string) (Proxy, error) {
+	u, err := url.Parse(link)
+	if err != nil {
+		return nil, err
+	}
+	host, port, err := hostPort(u)
+	if err != nil {
+		return nil, err
+	}
+	uuid := u.User.Username()
+	password, _ := u.User.Password()
+	if uuid == "" {
+		return nil, errors.New("tuic: missing uuid")
+	}
+	q := u.Query()
+	p := Proxy{
+		"name":     nameFrom(u, host, port),
+		"type":     "tuic",
+		"server":   host,
+		"port":     port,
+		"uuid":     uuid,
+		"password": password,
+	}
+	if sni := q.Get("sni"); sni != "" {
+		p["sni"] = sni
+	}
+	if alpn := q.Get("alpn"); alpn != "" {
+		p["alpn"] = splitCSV(alpn)
+	}
+	if cc := q.Get("congestion_control"); cc != "" {
+		p["congestion-controller"] = cc
+	}
+	if rm := q.Get("udp_relay_mode"); rm != "" {
+		p["udp-relay-mode"] = rm
+	}
+	if q.Get("allow_insecure") == "1" {
+		p["skip-cert-verify"] = true
+	}
+	return p, nil
+}
+
+// ---- helpers ----
+
+func applyTransport(p Proxy, network string, q url.Values) {
+	switch network {
+	case "ws":
+		ws := map[string]any{}
+		if path := q.Get("path"); path != "" {
+			ws["path"] = path
+		}
+		if host := q.Get("host"); host != "" {
+			ws["headers"] = map[string]any{"Host": host}
+		}
+		if len(ws) > 0 {
+			p["ws-opts"] = ws
+		}
+	case "grpc":
+		if sn := q.Get("serviceName"); sn != "" {
+			p["grpc-opts"] = map[string]any{"grpc-service-name": sn}
+		}
+	}
+}
+
+func applySSPlugin(p Proxy, plugin string) {
+	parts := strings.Split(plugin, ";")
+	name := parts[0]
+	opts := map[string]any{}
+	for _, kv := range parts[1:] {
+		k, v := splitEq(kv)
+		if k == "" {
+			continue
+		}
+		opts[k] = v
+	}
+	switch {
+	case strings.Contains(name, "obfs"):
+		p["plugin"] = "obfs"
+		mode := str(opts["obfs"])
+		po := map[string]any{}
+		if mode != "" {
+			po["mode"] = mode
+		}
+		if h := str(opts["obfs-host"]); h != "" {
+			po["host"] = h
+		}
+		p["plugin-opts"] = po
+	case strings.Contains(name, "v2ray"):
+		p["plugin"] = "v2ray-plugin"
+		p["plugin-opts"] = opts
+	default:
+		p["plugin"] = name
+		if len(opts) > 0 {
+			p["plugin-opts"] = opts
+		}
+	}
+}
+
+func hostPort(u *url.URL) (string, int, error) {
+	host := u.Hostname()
+	port, _ := strconv.Atoi(u.Port())
+	if host == "" || port == 0 {
+		return "", 0, errors.New("missing server/port")
+	}
+	return host, port, nil
+}
+
+func nameFrom(u *url.URL, host string, port int) string {
+	if n := decodeFragment(u.Fragment); n != "" {
+		return n
+	}
+	return fmt.Sprintf("%s:%d", host, port)
+}
+
+func decodeFragment(frag string) string {
+	if frag == "" {
+		return ""
+	}
+	if dec, err := url.QueryUnescape(frag); err == nil {
+		return strings.TrimSpace(dec)
+	}
+	return strings.TrimSpace(frag)
+}
+
+func decodeFlexible(s string) ([]byte, error) {
+	s = strings.TrimSpace(s)
+	for _, enc := range []*base64.Encoding{
+		base64.StdEncoding, base64.RawStdEncoding,
+		base64.URLEncoding, base64.RawURLEncoding,
+	} {
+		if dec, err := enc.DecodeString(s); err == nil {
+			return dec, nil
+		}
+	}
+	return nil, fmt.Errorf("not base64")
+}
+
+func dedupeNames(proxies []Proxy) {
+	seen := map[string]int{}
+	for _, p := range proxies {
+		n, _ := p["name"].(string)
+		if n == "" {
+			n = "proxy"
+			p["name"] = n
+		}
+		if c, ok := seen[n]; ok {
+			seen[n] = c + 1
+			p["name"] = fmt.Sprintf("%s #%d", n, c+1)
+		} else {
+			seen[n] = 1
+		}
+	}
+}
+
+func splitColon(s string) (string, string) {
+	a, b, _ := strings.Cut(s, ":")
+	return a, b
+}
+
+func splitEq(s string) (string, string) {
+	a, b, _ := strings.Cut(s, "=")
+	return strings.TrimSpace(a), strings.TrimSpace(b)
+}
+
+func splitHostPort(s string) (string, int) {
+	h, p, found := strings.Cut(s, ":")
+	if !found {
+		return s, 0
+	}
+	port, _ := strconv.Atoi(p)
+	return h, port
+}
+
+func splitCSV(s string) []string {
+	var out []string
+	for _, p := range strings.Split(s, ",") {
+		if p = strings.TrimSpace(p); p != "" {
+			out = append(out, p)
+		}
+	}
+	return out
+}
+
+func orDefault(v, def string) string {
+	if strings.TrimSpace(v) == "" {
+		return def
+	}
+	return v
+}
+
+func firstNonEmpty(vals ...string) string {
+	for _, v := range vals {
+		if strings.TrimSpace(v) != "" {
+			return v
+		}
+	}
+	return ""
+}
+
+func firstNonEmptyLine(s string) string {
+	for _, l := range strings.Split(normalizeNewlines(s), "\n") {
+		if t := strings.TrimSpace(l); t != "" {
+			return t
+		}
+	}
+	return ""
+}
+
+func normalizeNewlines(s string) string {
+	return strings.ReplaceAll(strings.ReplaceAll(s, "\r\n", "\n"), "\r", "\n")
+}
+
+func stripFragment(s string) string {
+	if i := strings.IndexByte(s, '#'); i >= 0 {
+		return s[:i]
+	}
+	return s
+}
+
+func str(v any) string {
+	switch t := v.(type) {
+	case string:
+		return t
+	case float64:
+		return strconv.FormatFloat(t, 'f', -1, 64)
+	case int:
+		return strconv.Itoa(t)
+	case nil:
+		return ""
+	default:
+		return fmt.Sprintf("%v", t)
+	}
+}
+
+func intish(v any) int {
+	switch t := v.(type) {
+	case float64:
+		return int(t)
+	case int:
+		return t
+	case string:
+		n, _ := strconv.Atoi(strings.TrimSpace(t))
+		return n
+	default:
+		return 0
+	}
+}
+
+func truncate(s string, n int) string {
+	if len(s) <= n {
+		return s
+	}
+	return s[:n] + "…"
+}

--- a/apps/sloth-clash-desktop/sharelink/sharelink_test.go
+++ b/apps/sloth-clash-desktop/sharelink/sharelink_test.go
@@ -1,0 +1,193 @@
+package sharelink
+
+import (
+	"encoding/base64"
+	"strings"
+	"testing"
+)
+
+func b64(s string) string { return base64.StdEncoding.EncodeToString([]byte(s)) }
+
+func TestParseVless(t *testing.T) {
+	link := "vless://11111111-2222-3333-4444-555555555555@example.com:443?type=ws&security=tls&sni=example.com&path=/ws&host=h.example.com&flow=xtls-rprx-vision#My Vless"
+	p, err := ParseLink(link)
+	if err != nil {
+		t.Fatalf("err: %v", err)
+	}
+	if p["type"] != "vless" || p["server"] != "example.com" || p["port"] != 443 {
+		t.Fatalf("base fields wrong: %#v", p)
+	}
+	if p["uuid"] != "11111111-2222-3333-4444-555555555555" {
+		t.Fatalf("uuid: %v", p["uuid"])
+	}
+	if p["tls"] != true || p["servername"] != "example.com" {
+		t.Fatalf("tls/sni: %#v", p)
+	}
+	if p["network"] != "ws" {
+		t.Fatalf("network: %v", p["network"])
+	}
+	ws, ok := p["ws-opts"].(map[string]any)
+	if !ok || ws["path"] != "/ws" {
+		t.Fatalf("ws-opts: %#v", p["ws-opts"])
+	}
+	if p["name"] != "My Vless" {
+		t.Fatalf("name: %v", p["name"])
+	}
+	if p["flow"] != "xtls-rprx-vision" {
+		t.Fatalf("flow: %v", p["flow"])
+	}
+}
+
+func TestParseVlessReality(t *testing.T) {
+	link := "vless://uuid@1.2.3.4:443?security=reality&pbk=PUBKEY&sid=ab12&fp=chrome&type=grpc&serviceName=gsvc#R"
+	p, err := ParseLink(link)
+	if err != nil {
+		t.Fatalf("err: %v", err)
+	}
+	ro, ok := p["reality-opts"].(map[string]any)
+	if !ok || ro["public-key"] != "PUBKEY" || ro["short-id"] != "ab12" {
+		t.Fatalf("reality-opts: %#v", p["reality-opts"])
+	}
+	if p["client-fingerprint"] != "chrome" {
+		t.Fatalf("fp: %v", p["client-fingerprint"])
+	}
+	grpc, ok := p["grpc-opts"].(map[string]any)
+	if !ok || grpc["grpc-service-name"] != "gsvc" {
+		t.Fatalf("grpc-opts: %#v", p["grpc-opts"])
+	}
+}
+
+func TestParseVmess(t *testing.T) {
+	j := `{"v":"2","ps":"My Vmess","add":"example.com","port":"443","id":"uuid-x","aid":"0","scy":"auto","net":"ws","host":"h.example.com","path":"/p","tls":"tls"}`
+	link := "vmess://" + b64(j)
+	p, err := ParseLink(link)
+	if err != nil {
+		t.Fatalf("err: %v", err)
+	}
+	if p["type"] != "vmess" || p["server"] != "example.com" || p["port"] != 443 {
+		t.Fatalf("base: %#v", p)
+	}
+	if p["uuid"] != "uuid-x" || p["cipher"] != "auto" || p["alterId"] != 0 {
+		t.Fatalf("vmess fields: %#v", p)
+	}
+	if p["tls"] != true || p["servername"] != "h.example.com" {
+		t.Fatalf("tls: %#v", p)
+	}
+	ws, ok := p["ws-opts"].(map[string]any)
+	if !ok || ws["path"] != "/p" {
+		t.Fatalf("ws-opts: %#v", p["ws-opts"])
+	}
+}
+
+func TestParseSSSIP002(t *testing.T) {
+	link := "ss://" + b64("aes-256-gcm:secretpass") + "@example.com:8388#My SS"
+	p, err := ParseLink(link)
+	if err != nil {
+		t.Fatalf("err: %v", err)
+	}
+	if p["type"] != "ss" || p["cipher"] != "aes-256-gcm" || p["password"] != "secretpass" {
+		t.Fatalf("ss fields: %#v", p)
+	}
+	if p["server"] != "example.com" || p["port"] != 8388 {
+		t.Fatalf("server/port: %#v", p)
+	}
+	if p["name"] != "My SS" {
+		t.Fatalf("name: %v", p["name"])
+	}
+}
+
+func TestParseSSLegacy(t *testing.T) {
+	link := "ss://" + b64("aes-128-gcm:pw@example.com:8388") + "#Legacy"
+	p, err := ParseLink(link)
+	if err != nil {
+		t.Fatalf("err: %v", err)
+	}
+	if p["cipher"] != "aes-128-gcm" || p["password"] != "pw" || p["port"] != 8388 {
+		t.Fatalf("legacy ss: %#v", p)
+	}
+}
+
+func TestParseTrojan(t *testing.T) {
+	link := "trojan://mypassword@example.com:443?sni=example.com&allowInsecure=1#T"
+	p, err := ParseLink(link)
+	if err != nil {
+		t.Fatalf("err: %v", err)
+	}
+	if p["type"] != "trojan" || p["password"] != "mypassword" || p["sni"] != "example.com" {
+		t.Fatalf("trojan: %#v", p)
+	}
+	if p["skip-cert-verify"] != true {
+		t.Fatalf("insecure: %#v", p)
+	}
+}
+
+func TestParseHysteria2(t *testing.T) {
+	link := "hysteria2://pass@example.com:443?sni=example.com&obfs=salamander&obfs-password=xyz&insecure=1#H"
+	p, err := ParseLink(link)
+	if err != nil {
+		t.Fatalf("err: %v", err)
+	}
+	if p["type"] != "hysteria2" || p["password"] != "pass" || p["obfs"] != "salamander" {
+		t.Fatalf("hy2: %#v", p)
+	}
+	if p["obfs-password"] != "xyz" || p["skip-cert-verify"] != true {
+		t.Fatalf("hy2 opts: %#v", p)
+	}
+}
+
+func TestParseTuic(t *testing.T) {
+	link := "tuic://uuid-1:password-1@example.com:443?sni=example.com&congestion_control=bbr&udp_relay_mode=native#U"
+	p, err := ParseLink(link)
+	if err != nil {
+		t.Fatalf("err: %v", err)
+	}
+	if p["type"] != "tuic" || p["uuid"] != "uuid-1" || p["password"] != "password-1" {
+		t.Fatalf("tuic: %#v", p)
+	}
+	if p["congestion-controller"] != "bbr" || p["udp-relay-mode"] != "native" {
+		t.Fatalf("tuic opts: %#v", p)
+	}
+}
+
+func TestParseManyAndDedupe(t *testing.T) {
+	text := strings.Join([]string{
+		"trojan://pw@a.com:443#dup",
+		"trojan://pw@b.com:443#dup",
+		"garbage://nope",
+		"# comment",
+		"",
+	}, "\n")
+	proxies, skipped := ParseMany(text)
+	if len(proxies) != 2 {
+		t.Fatalf("want 2 proxies, got %d", len(proxies))
+	}
+	if proxies[0]["name"] == proxies[1]["name"] {
+		t.Fatalf("names not deduped: %v / %v", proxies[0]["name"], proxies[1]["name"])
+	}
+	if len(skipped) != 1 || !strings.HasPrefix(skipped[0], "garbage://") {
+		t.Fatalf("skipped: %#v", skipped)
+	}
+}
+
+func TestLooksLikeShareLinksAndBase64Block(t *testing.T) {
+	plain := "vless://uuid@a.com:443#x\ntrojan://pw@b.com:443#y"
+	if !LooksLikeShareLinks(plain) {
+		t.Fatal("plain should look like share links")
+	}
+	enc := base64.StdEncoding.EncodeToString([]byte(plain))
+	if !LooksLikeShareLinks(enc) {
+		t.Fatal("base64 envelope should look like share links")
+	}
+	if got := DecodeBase64Block(enc); !strings.Contains(got, "vless://") {
+		t.Fatalf("decode block: %q", got)
+	}
+	if LooksLikeShareLinks("proxies:\n  - {}") {
+		t.Fatal("clash yaml should not look like share links")
+	}
+}
+
+func TestUnsupportedScheme(t *testing.T) {
+	if _, err := ParseLink("ssr://whatever"); err == nil {
+		t.Fatal("expected error for ssr")
+	}
+}

--- a/apps/sloth-clash-desktop/subscription_yaml.go
+++ b/apps/sloth-clash-desktop/subscription_yaml.go
@@ -7,6 +7,8 @@ import (
 	"strconv"
 	"strings"
 
+	"SlothClashDesktop/sharelink"
+
 	"gopkg.in/yaml.v3"
 )
 
@@ -248,10 +250,47 @@ func parseClashDocToMap(b []byte) (map[string]any, error) {
 			return m2, nil
 		}
 	}
+	// Not Clash YAML (plain or base64). Try a V2Ray-style share-link list
+	// (vless://, vmess://, ss://, trojan://, hysteria2://, tuic://) — single
+	// link, newline list, or base64 envelope — and synthesize a runnable config.
+	if doc, ok := shareLinksToClashMap(string(b)); ok {
+		return doc, nil
+	}
 	if err != nil {
 		return nil, err
 	}
 	return nil, errors.New("invalid clash yaml mapping")
+}
+
+// shareLinksToClashMap converts proxy share links into a minimal but complete
+// Clash/mihomo config map: the parsed proxies, a default `PROXY` select group
+// (all nodes + DIRECT), and a catch-all rule. Returns ok=false if no supported
+// link is found. Having proxy-groups + rules makes the result a "full profile"
+// so the normal merge pipeline handles ports/TUN/overlay uniformly.
+func shareLinksToClashMap(text string) (map[string]any, bool) {
+	proxies, _ := sharelink.ParseMany(text)
+	if len(proxies) == 0 {
+		if dec := sharelink.DecodeBase64Block(text); dec != "" {
+			proxies, _ = sharelink.ParseMany(dec)
+		}
+	}
+	if len(proxies) == 0 {
+		return nil, false
+	}
+	rawProxies := make([]any, 0, len(proxies))
+	groupProxies := make([]any, 0, len(proxies)+1)
+	for _, p := range proxies {
+		rawProxies = append(rawProxies, map[string]any(p))
+		groupProxies = append(groupProxies, p["name"])
+	}
+	groupProxies = append(groupProxies, "DIRECT")
+	return map[string]any{
+		"proxies": rawProxies,
+		"proxy-groups": []any{
+			map[string]any{"name": "PROXY", "type": "select", "proxies": groupProxies},
+		},
+		"rules": []any{"MATCH,PROXY"},
+	}, true
 }
 
 // subscriptionDocIsFullProfile reports whether the downloaded document should be used as the


### PR DESCRIPTION
Add a pure-Go sharelink package converting vless/vmess/ss/trojan/hysteria2/tuic links to mihomo proxies. New ImportProfileFromText creates a local (URL-less) profile from pasted/loaded content - Clash YAML, a share-link list, or a base64 subscription envelope - validated and seeded into the profile body cache. parseClashDocToMap gains a share-link fallthrough so subscription URLs returning a link list also work. ResetSubscriptionCache refuses to wipe a local profile's only copy. Import dialog gains a Paste/File mode with live content detection.