### PR TITLE
fix(build): commit ImportProfileFromText wails binding

### DIFF
--- a/apps/sloth-clash-desktop/frontend/wailsjs/go/main/App.d.ts
+++ b/apps/sloth-clash-desktop/frontend/wailsjs/go/main/App.d.ts
@@ -55,6 +55,11 @@ export function GetTunStatus(): Promise<main.ServiceState>
 
 export function GetUpdateState(): Promise<main.UpdateState>
 
+export function ImportProfileFromText(
+  arg1: string,
+  arg2: string,
+): Promise<main.AppState>
+
 export function ImportProfileFromURL(
   arg1: string,
   arg2: string,

--- a/apps/sloth-clash-desktop/frontend/wailsjs/go/main/App.js
+++ b/apps/sloth-clash-desktop/frontend/wailsjs/go/main/App.js
@@ -98,6 +98,10 @@ export function GetUpdateState() {
   return window['go']['main']['App']['GetUpdateState']()
 }
 
+export function ImportProfileFromText(arg1, arg2) {
+  return window['go']['main']['App']['ImportProfileFromText'](arg1, arg2)
+}
+
 export function ImportProfileFromURL(arg1, arg2) {
   return window['go']['main']['App']['ImportProfileFromURL'](arg1, arg2)
 }


### PR DESCRIPTION
The frontend imports ImportProfileFromText, but its wailsjs binding was not committed, so CI (tsc && vite build, which does not regenerate bindings) failed on all OSes with TS2724. Add the minimal binding export to App.js and App.d.ts.