### PR TITLE
feat(ui): Proxies single-open accordion redesign

### DIFF
--- a/apps/sloth-clash-desktop/frontend/src/App.css
+++ b/apps/sloth-clash-desktop/frontend/src/App.css
@@ -410,9 +410,9 @@
 }
 
 .shell[data-theme="light"] .proxyTypeChip {
-  background: rgba(34, 120, 70, 0.14);
-  border-color: rgba(34, 120, 70, 0.32);
-  color: #1f6b43;
+  background: rgba(90, 80, 60, 0.1);
+  border-color: rgba(90, 80, 60, 0.28);
+  color: var(--text-muted);
 }
 
 .shell[data-theme="light"] .proxyCountChip {
@@ -1068,14 +1068,67 @@
 .proxyTypeChip {
   display: inline-flex;
   align-items: center;
-  padding: 1px 6px;
-  border-radius: 999px;
+  padding: 1px 7px;
+  border-radius: var(--radius-pill);
+  font-family: var(--font-mono);
   font-size: var(--font-size-xs);
+  font-weight: 600;
   text-transform: uppercase;
-  letter-spacing: 0.04em;
-  background: rgba(90, 184, 120, 0.15);
-  border: 1px solid rgba(90, 184, 120, 0.35);
-  color: #b8f2cb;
+  letter-spacing: 0.07em;
+  /* default (unknown type) — neutral; per-type colours override below */
+  background: rgba(150, 150, 150, 0.14);
+  border: 1px solid rgba(150, 150, 150, 0.32);
+  color: var(--text-muted);
+}
+
+/* Per-type colours (no blue): url-test=emerald, selector=purple,
+   fallback=turquoise, load-balance=olive. */
+.proxyType-urltest {
+  background: rgba(46, 204, 113, 0.16);
+  border-color: rgba(46, 204, 113, 0.4);
+  color: #7ee0a8;
+}
+
+.proxyType-selector {
+  background: rgba(167, 139, 250, 0.16);
+  border-color: rgba(167, 139, 250, 0.42);
+  color: #c4b5fd;
+}
+
+.proxyType-fallback {
+  background: rgba(45, 212, 191, 0.16);
+  border-color: rgba(45, 212, 191, 0.4);
+  color: #5eead4;
+}
+
+.proxyType-loadbalance {
+  background: rgba(170, 170, 70, 0.18);
+  border-color: rgba(170, 170, 70, 0.45);
+  color: #d2d27a;
+}
+
+.shell[data-theme="light"] .proxyType-urltest {
+  background: rgba(34, 150, 84, 0.14);
+  border-color: rgba(34, 150, 84, 0.34);
+  color: #1f7a44;
+}
+
+.shell[data-theme="light"] .proxyType-selector {
+  background: rgba(124, 92, 214, 0.14);
+  border-color: rgba(124, 92, 214, 0.34);
+  color: #6a45b8;
+}
+
+.shell[data-theme="light"] .proxyType-fallback {
+  background: rgba(20, 150, 135, 0.14);
+  border-color: rgba(20, 150, 135, 0.34);
+  color: #0f766e;
+}
+
+.shell[data-theme="light"] .proxyType-loadbalance {
+  background: rgba(120, 120, 40, 0.16);
+  border-color: rgba(120, 120, 40, 0.42);
+  color: #5f5f1e;
 }
 
 .proxyCountChip {
@@ -3213,6 +3266,254 @@
 .proxyToolbar .btn {
   padding: var(--space-1) var(--space-3);
   font-size: var(--font-size-sm);
+}
+
+/* === Proxies single-open accordion (proxies-redesign) === */
+.proxyAccordion {
+  flex: 1 1 auto;
+  min-height: 0;
+  display: flex;
+  flex-direction: column;
+  margin-top: var(--space-3);
+}
+
+.proxyAccFilterRow {
+  flex: 0 0 auto;
+  margin-bottom: var(--space-2);
+}
+
+.proxyAccGroupSearch {
+  width: 100%;
+  box-sizing: border-box;
+  padding: var(--space-2) var(--space-3);
+  border-radius: var(--radius-md);
+  border: 1px solid var(--hairline-strong);
+  background: rgba(0, 0, 0, 0.22);
+  color: var(--text);
+  font: inherit;
+  font-size: var(--font-size-sm);
+  outline: none;
+}
+
+.proxyAccGroupSearch:focus {
+  border-color: var(--accent-muted);
+}
+
+.shell[data-theme="light"] .proxyAccGroupSearch {
+  background: #fdf9f0;
+}
+
+.proxyAccActionEmoji {
+  font-size: 0.95em;
+  line-height: 1;
+}
+
+.proxyAccAction {
+  display: inline-flex;
+  align-items: center;
+  gap: var(--space-1);
+  white-space: nowrap;
+}
+
+.proxyAccList {
+  flex: 1 1 auto;
+  min-height: 0;
+  overflow-y: auto;
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-2);
+  padding-right: var(--space-1);
+}
+
+.proxyAccEmpty {
+  margin: var(--space-3) 0;
+}
+
+.proxyAccHealth {
+  font-size: var(--font-size-xs);
+  color: var(--text-muted);
+  white-space: nowrap;
+}
+
+.proxyAccFastest,
+.proxyAccDensity {
+  white-space: nowrap;
+}
+
+.proxyDelayBar {
+  display: block;
+  height: 3px;
+  margin-top: var(--space-1);
+  border-radius: var(--radius-pill);
+  background: rgba(255, 255, 255, 0.08);
+  overflow: hidden;
+}
+
+.shell[data-theme="light"] .proxyDelayBar {
+  background: rgba(74, 55, 30, 0.1);
+}
+
+.proxyDelayBarFill {
+  display: block;
+  height: 100%;
+  border-radius: inherit;
+}
+
+.proxyDelayBarGood .proxyDelayBarFill {
+  background: var(--ok);
+}
+
+.proxyDelayBarOk .proxyDelayBarFill {
+  background: var(--warn);
+}
+
+.proxyDelayBarSlow .proxyDelayBarFill {
+  background: var(--danger);
+}
+
+.proxyNodesGrid.compact {
+  grid-template-columns: repeat(auto-fill, minmax(150px, 1fr));
+  gap: var(--space-1);
+}
+
+.proxyNodesGrid.compact .proxyNodeCard {
+  padding: var(--space-1) var(--space-2);
+}
+
+.proxyAccGroup {
+  flex: 0 0 auto;
+  border: 1px solid var(--hairline);
+  border-radius: var(--radius-md);
+  background: rgba(0, 0, 0, 0.14);
+  overflow: hidden;
+}
+
+.proxyAccGroup.open {
+  border-color: var(--accent-muted);
+}
+
+.shell[data-theme="light"] .proxyAccGroup {
+  background: rgba(74, 55, 30, 0.04);
+}
+
+.proxyAccHeader {
+  display: flex;
+  align-items: center;
+  gap: var(--space-2);
+  width: 100%;
+  box-sizing: border-box;
+  text-align: left;
+  border: 0;
+  background: transparent;
+  color: var(--text);
+  cursor: pointer;
+  padding: var(--space-2) var(--space-3);
+  font: inherit;
+  outline: none;
+}
+
+/* Kill the default full-width focus rectangle (showed as a stray white stripe
+   on click); keep an inset accent ring for keyboard users only. */
+.proxyAccHeader:focus-visible {
+  outline: 2px solid var(--accent-muted);
+  outline-offset: -2px;
+  border-radius: var(--radius-md);
+}
+
+.proxyAccHeader:hover {
+  background: rgba(255, 255, 255, 0.04);
+}
+
+.shell[data-theme="light"] .proxyAccHeader:hover {
+  background: rgba(74, 55, 30, 0.05);
+}
+
+.proxyAccName {
+  font-weight: var(--weight-semibold);
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  max-width: 40%;
+}
+
+.proxyAccCurrent {
+  margin-left: auto;
+  display: inline-flex;
+  align-items: center;
+  gap: var(--space-1);
+  min-width: 0;
+  color: var(--text-muted);
+  font-size: var(--font-size-sm);
+}
+
+.proxyAccCurrentName {
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+  max-width: 220px;
+}
+
+.proxyAccChevron {
+  flex: 0 0 auto;
+  width: 16px;
+  height: 16px;
+  color: var(--text-muted);
+  transition: transform var(--dur-base) var(--ease-standard);
+}
+
+.proxyAccGroup.open .proxyAccChevron {
+  transform: rotate(180deg);
+}
+
+.proxyAccBody {
+  padding: 0 var(--space-3) var(--space-3);
+}
+
+/* Nodes scroll inside the open group so collapsed groups below stay reachable
+   instead of pushing the accordion into a long scroll. */
+.proxyAccBody .proxyNodesGrid {
+  max-height: clamp(180px, 38vh, 420px);
+  overflow-y: auto;
+  padding-right: var(--space-1);
+}
+
+.proxyAccActions {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: center;
+  gap: var(--space-2);
+  margin-bottom: var(--space-2);
+}
+
+.proxyAccSort {
+  flex: 0 0 auto;
+  width: auto;
+  min-width: 120px;
+  max-width: 160px;
+}
+
+.proxyAccHideDead.isOn {
+  background: var(--accent-dim);
+  color: var(--text);
+}
+
+.proxyAccSearch {
+  margin-left: auto;
+  width: auto;
+  min-width: 150px;
+  max-width: 240px;
+}
+
+.proxyDelayGood {
+  color: var(--ok);
+}
+
+.proxyDelayOk {
+  color: var(--warn);
+}
+
+.proxyDelaySlow {
+  color: var(--danger);
 }
 
 .policyHint {

--- a/apps/sloth-clash-desktop/frontend/src/locales/en.json
+++ b/apps/sloth-clash-desktop/frontend/src/locales/en.json
@@ -163,7 +163,19 @@
       "searchNode": "Search nodes...",
       "noGroupMatch": "No groups match.",
       "noNodeMatch": "No nodes match.",
-      "pickGroupHint": "Pick a group on the left to see its nodes."
+      "pickGroupHint": "Pick a group on the left to see its nodes.",
+      "sortLabel": "Sort nodes",
+      "sortDefault": "Default order",
+      "sortLatency": "By latency",
+      "sortName": "By name",
+      "hideDead": "Hide dead",
+      "healthTitle": "Alive / total nodes · best latency",
+      "selectFastest": "Select fastest",
+      "pingAllShort": "Ping all",
+      "fastest": "Fastest",
+      "density": "Toggle node density",
+      "densityCompact": "Compact",
+      "densityComfortable": "Comfortable"
     },
     "rules": {
       "title": "Rules",

--- a/apps/sloth-clash-desktop/frontend/src/locales/ru.json
+++ b/apps/sloth-clash-desktop/frontend/src/locales/ru.json
@@ -163,7 +163,19 @@
       "searchNode": "Поиск нод...",
       "noGroupMatch": "Группы не найдены.",
       "noNodeMatch": "Ноды не найдены.",
-      "pickGroupHint": "Выберите группу слева, чтобы увидеть её ноды."
+      "pickGroupHint": "Выберите группу слева, чтобы увидеть её ноды.",
+      "sortLabel": "Сортировка нод",
+      "sortDefault": "По умолчанию",
+      "sortLatency": "По задержке",
+      "sortName": "По имени",
+      "hideDead": "Скрыть мёртвые",
+      "healthTitle": "Живых / всего нод · лучшая задержка",
+      "selectFastest": "Выбрать быстрейший",
+      "pingAllShort": "Пинг всех",
+      "fastest": "Быстрейший",
+      "density": "Плотность карточек",
+      "densityCompact": "Компактно",
+      "densityComfortable": "Просторно"
     },
     "rules": {
       "title": "Правила",

--- a/apps/sloth-clash-desktop/frontend/src/locales/zh.json
+++ b/apps/sloth-clash-desktop/frontend/src/locales/zh.json
@@ -163,7 +163,19 @@
       "searchNode": "搜索节点...",
       "noGroupMatch": "未找到分组。",
       "noNodeMatch": "未找到节点。",
-      "pickGroupHint": "在左侧选择分组以查看其节点。"
+      "pickGroupHint": "在左侧选择分组以查看其节点。",
+      "sortLabel": "节点排序",
+      "sortDefault": "默认顺序",
+      "sortLatency": "按延迟",
+      "sortName": "按名称",
+      "hideDead": "隐藏失效",
+      "healthTitle": "存活 / 总节点数 · 最佳延迟",
+      "selectFastest": "选择最快",
+      "pingAllShort": "全部测速",
+      "fastest": "最快",
+      "density": "切换节点密度",
+      "densityCompact": "紧凑",
+      "densityComfortable": "宽松"
     },
     "rules": {
       "title": "规则",

--- a/apps/sloth-clash-desktop/frontend/src/pages/Proxies.tsx
+++ b/apps/sloth-clash-desktop/frontend/src/pages/Proxies.tsx
@@ -1,4 +1,4 @@
-import { type CSSProperties, useMemo, useState } from 'react'
+import { type CSSProperties, useEffect, useRef, useState } from 'react'
 import { useTranslation } from 'react-i18next'
 
 import { FlagMark } from '../components/FlagMark'
@@ -12,9 +12,7 @@ import {
 import { friendlyErrorMessage } from '../utils/yaml'
 
 // Mihomo /proxies/{name}/delay surfaces a handful of recurring failure modes.
-// Inline-rendering the raw error string blew the chip layout (the URL alone
-// is ~70 chars). Map to a short label so the chip stays compact; the full
-// message is preserved in title= for hover/inspection.
+// Map to a short label so the chip stays compact; full message stays in title=.
 function shortProxyDelayError(raw: string | undefined): string {
   if (!raw) return ''
   const s = String(raw)
@@ -29,9 +27,87 @@ function shortProxyDelayError(raw: string | undefined): string {
   return 'fail'
 }
 
+// Latency bands → quality class for at-a-glance colouring.
+function delayBand(ms: number): 'good' | 'ok' | 'slow' | '' {
+  if (ms <= 0) return ''
+  if (ms < 120) return 'good'
+  if (ms < 300) return 'ok'
+  return 'slow'
+}
+
+// Bar fill (%) by band — a quick visual on top of the colour.
+function delayBarPct(ms: number): number {
+  const b = delayBand(ms)
+  if (b === 'good') return 100
+  if (b === 'ok') return 66
+  if (b === 'slow') return 33
+  return 0
+}
+
+type GroupHealth = { alive: number; total: number; best: number }
+
+function groupHealth(
+  proxies: string[],
+  delayMap: Record<string, number>,
+  delayErr: Record<string, string>,
+): GroupHealth {
+  let alive = 0
+  let best = 0
+  for (const p of proxies) {
+    const d = delayMap[p] ?? 0
+    if (d > 0 && !delayErr[p]) {
+      alive++
+      if (best === 0 || d < best) best = d
+    }
+  }
+  return { alive, total: proxies.length, best }
+}
+
+function fastestNode(
+  proxies: string[],
+  delayMap: Record<string, number>,
+  delayErr: Record<string, string>,
+): string {
+  let best = ''
+  let bestD = Number.POSITIVE_INFINITY
+  for (const p of proxies) {
+    const d = delayMap[p] ?? 0
+    if (d > 0 && !delayErr[p] && d < bestD) {
+      bestD = d
+      best = p
+    }
+  }
+  return best
+}
+
+type SortMode = 'default' | 'latency' | 'name'
+type Density = 'comfortable' | 'compact'
+
+const LS = {
+  open: 'slothProxies.open',
+  sort: 'slothProxies.sort',
+  hideDead: 'slothProxies.hideDead',
+  density: 'slothProxies.density',
+}
+
+function lsGet(key: string, fallback: string): string {
+  try {
+    return localStorage.getItem(key) ?? fallback
+  } catch {
+    return fallback
+  }
+}
+
+function lsSet(key: string, value: string): void {
+  try {
+    localStorage.setItem(key, value)
+  } catch {
+    /* ignore */
+  }
+}
+
 export function ProxiesPage({
   groups,
-  activeGroup,
   connectionStatus,
   displayMode,
   showBuiltin,
@@ -42,7 +118,6 @@ export function ProxiesPage({
   onRefreshProxies,
   onToggleShowBuiltin,
   onSetMode,
-  onSelectGroup,
   onSelectNode,
   onPingAll,
 }: {
@@ -63,12 +138,6 @@ export function ProxiesPage({
   onPingAll: (group: string, nodes: string[]) => void
 }) {
   const { t } = useTranslation()
-  // GLOBAL is mihomo's built-in catch-all group — it's relevant only in
-  // global mode (where every flow funnels through it). In rule mode the
-  // rules decide the routing and GLOBAL is never used, so the upstream
-  // (clash-verge-rev) hides it from the picker to avoid the user mistaking
-  // it for a real selector. We do the same: hide when mode === 'rule', show
-  // when mode === 'global' or when the user explicitly turns built-ins on.
   const visibleGroups = groups.filter((g: any) => {
     const name = String(g?.name ?? '')
     if (!showBuiltin) {
@@ -78,6 +147,7 @@ export function ProxiesPage({
     }
     return true
   })
+
   return (
     <div className="panel proxiesPanel">
       <h2>{t('ui.proxies.title')}</h2>
@@ -92,9 +162,7 @@ export function ProxiesPage({
             className="segmentGlider"
             aria-hidden
             style={
-              {
-                '--seg-i': displayMode === 'rule' ? 0 : 1,
-              } as CSSProperties
+              { '--seg-i': displayMode === 'rule' ? 0 : 1 } as CSSProperties
             }
           />
           <button
@@ -120,25 +188,6 @@ export function ProxiesPage({
             {t('ui.common.global')}
           </button>
         </div>
-        <label className="proxyFocusGroup">
-          <span className="segLabel">{t('ui.proxies.focusGroup')}</span>
-          <select
-            className="selectModern"
-            value={activeGroup}
-            onChange={(e) => {
-              const v = e.target.value
-              if (!v) return
-              onSelectGroup(v)
-            }}
-          >
-            <option value="">—</option>
-            {visibleGroups.map((g: any) => (
-              <option key={g.name} value={g.name}>
-                {`${g.name} (${g.type})`}
-              </option>
-            ))}
-          </select>
-        </label>
         <div className="proxyToolbarActions">
           <button
             type="button"
@@ -157,7 +206,7 @@ export function ProxiesPage({
           </button>
         </div>
       </div>
-      <ProxyGroupsSplit
+      <ProxyGroupsAccordion
         visibleGroups={visibleGroups}
         connectionStatus={connectionStatus}
         showBuiltin={showBuiltin}
@@ -172,7 +221,7 @@ export function ProxiesPage({
   )
 }
 
-type SplitProps = {
+type AccordionProps = {
   visibleGroups: any[]
   connectionStatus: string
   showBuiltin: boolean
@@ -184,13 +233,13 @@ type SplitProps = {
 }
 
 /**
- * Two-pane proxy groups layout (upstream Verge-Rev pattern). Left rail holds
- * a dense list of groups with their selected node summary so the user can
- * eyeball the whole topology at once; right pane focuses on the active
- * group's nodes with its own search. Scales gracefully from 1 group to 50+
- * without the page turning into an endless scroll of expanded cards.
+ * Single-open accordion: groups are full-width rows; clicking one expands its
+ * nodes inline. Adds a group quick-filter, per-group health (alive/total +
+ * best latency), auto-test + "select fastest", latency bars, density toggle,
+ * and persists the open group / sort / filters. "Our own" take on the
+ * FlClashX / mobile accordion — not a 1:1 clash-verge clone.
  */
-function ProxyGroupsSplit({
+function ProxyGroupsAccordion({
   visibleGroups,
   connectionStatus,
   showBuiltin,
@@ -199,245 +248,363 @@ function ProxyGroupsSplit({
   proxyDelayErr,
   onSelectNode,
   onPingAll,
-}: SplitProps) {
+}: AccordionProps) {
   const { t } = useTranslation()
   const [groupSearch, setGroupSearch] = useState('')
+  const [openName, setOpenName] = useState(() => lsGet(LS.open, ''))
   const [nodeSearch, setNodeSearch] = useState('')
-  const [focusedName, setFocusedName] = useState<string>('')
-
-  const groupList = useMemo(() => {
-    const q = groupSearch.trim().toLowerCase()
-    if (!q) return visibleGroups
-    return visibleGroups.filter((g: any) =>
-      String(g.name ?? '')
-        .toLowerCase()
-        .includes(q),
-    )
-  }, [visibleGroups, groupSearch])
-
-  // Derive the effective focused group during render. This avoids a setState
-  // effect (which the React lint flags) by treating focusedName as a "hint"
-  // and falling back to the first available group when the hint no longer
-  // matches anything in the filtered list.
-  const effectiveFocused = useMemo(() => {
-    if (groupList.length === 0) return ''
-    if (
-      focusedName &&
-      groupList.some((g: any) => String(g.name ?? '') === focusedName)
-    ) {
-      return focusedName
-    }
-    return String(groupList[0]?.name ?? '')
-  }, [groupList, focusedName])
-
-  const focused = useMemo(
-    () =>
-      visibleGroups.find((g: any) => String(g.name ?? '') === effectiveFocused),
-    [visibleGroups, effectiveFocused],
+  const [sortMode, setSortMode] = useState<SortMode>(
+    () => lsGet(LS.sort, 'default') as SortMode,
   )
+  const [hideDead, setHideDead] = useState(
+    () => lsGet(LS.hideDead, '0') === '1',
+  )
+  const [density, setDensity] = useState<Density>(
+    () => lsGet(LS.density, 'compact') as Density,
+  )
+  const autoTestedRef = useRef<Set<string>>(new Set())
+  const activeCardRef = useRef<HTMLButtonElement | null>(null)
+
+  const connected = connectionStatus === 'connected'
+
+  useEffect(() => lsSet(LS.open, openName), [openName])
+  useEffect(() => lsSet(LS.sort, sortMode), [sortMode])
+  useEffect(() => lsSet(LS.hideDead, hideDead ? '1' : '0'), [hideDead])
+  useEffect(() => lsSet(LS.density, density), [density])
+
+  // Auto-test the open group's nodes once, if they have no delays yet — so
+  // opening a group surfaces live latencies without a manual ping.
+  useEffect(() => {
+    if (!openName || !connected) return
+    if (autoTestedRef.current.has(openName)) return
+    const g = visibleGroups.find((x: any) => String(x.name ?? '') === openName)
+    if (!g) return
+    const ps = filterProxyNodesForDisplay(
+      (g.proxies ?? []) as string[],
+      showBuiltin,
+      String(g.selected ?? ''),
+    )
+    if (ps.length === 0) return
+    const anyMeasured = ps.some(
+      (p) => (proxyDelayMap[p] ?? 0) > 0 || proxyDelayErr[p],
+    )
+    if (!anyMeasured) {
+      autoTestedRef.current.add(openName)
+      onPingAll(openName, ps)
+    }
+  }, [
+    openName,
+    connected,
+    visibleGroups,
+    showBuiltin,
+    proxyDelayMap,
+    proxyDelayErr,
+    onPingAll,
+  ])
+
+  // Scroll the selected node into view when a group opens.
+  useEffect(() => {
+    activeCardRef.current?.scrollIntoView({ block: 'nearest' })
+  }, [openName])
 
   if (visibleGroups.length === 0) {
     return (
       <p className="muted">
-        {connectionStatus === 'connected'
-          ? t('ui.proxies.noGroups')
-          : t('ui.proxies.connectFirst')}
+        {connected ? t('ui.proxies.noGroups') : t('ui.proxies.connectFirst')}
       </p>
     )
   }
 
-  const focusedProxies: string[] = focused
-    ? filterProxyNodesForDisplay(
-        (focused.proxies ?? []) as string[],
-        showBuiltin,
-        String(focused.selected ?? ''),
+  const gq = groupSearch.trim().toLowerCase()
+  const shownGroups = gq
+    ? visibleGroups.filter((g: any) =>
+        String(g.name ?? '')
+          .toLowerCase()
+          .includes(gq),
       )
-    : []
-  const focusedType = String(focused?.type ?? '')
-    .toLowerCase()
-    .replace(/-/g, '')
-  const focusedIsAuto =
-    focusedType === 'urltest' ||
-    focusedType === 'fallback' ||
-    focusedType === 'loadbalance'
-  const focusedPingKey = focused ? `__all_${String(focused.name)}` : ''
-  const focusedNodeQ = nodeSearch.trim().toLowerCase()
-  const filteredNodes = focusedNodeQ
-    ? focusedProxies.filter(
-        (p) =>
-          nodeDisplayName(p).toLowerCase().includes(focusedNodeQ) ||
-          p.toLowerCase().includes(focusedNodeQ),
+    : visibleGroups
+
+  const sortNodes = (nodes: string[]): string[] => {
+    if (sortMode === 'name') {
+      return [...nodes].sort((a, b) =>
+        nodeDisplayName(a).localeCompare(nodeDisplayName(b)),
       )
-    : focusedProxies
+    }
+    if (sortMode === 'latency') {
+      const rank = (p: string): number => {
+        if (proxyDelayErr[p]) return Number.MAX_SAFE_INTEGER
+        const d = proxyDelayMap[p] ?? 0
+        return d > 0 ? d : Number.MAX_SAFE_INTEGER - 1
+      }
+      return [...nodes].sort((a, b) => rank(a) - rank(b))
+    }
+    return nodes
+  }
 
   return (
-    <div className="proxySplit">
-      <aside className="proxySplitSidebar">
-        <div className="proxySplitSearchRow">
-          <input
-            type="text"
-            value={groupSearch}
-            onChange={(e) => setGroupSearch(e.target.value)}
-            placeholder={t('ui.proxies.searchGroup')}
-            className="inputModern"
-            aria-label={t('ui.proxies.searchGroup')}
-          />
-        </div>
-        <ul className="proxySplitGroupList" role="listbox">
-          {groupList.map((g: any) => {
-            const name = String(g.name ?? '')
-            const selectedIso = extractNodeFlagIso(String(g.selected ?? ''))
-            const isFocused = name === effectiveFocused
-            return (
-              <li key={name}>
-                <button
-                  type="button"
-                  className={`proxySplitGroupItem${isFocused ? ' active' : ''}`}
-                  onClick={() => setFocusedName(name)}
-                  role="option"
-                  aria-selected={isFocused}
-                >
-                  <div className="proxySplitGroupItemTop">
-                    <span className="proxySplitGroupName">{name}</span>
-                    <span className="proxyCountChip">
-                      {(g.proxies ?? []).length}
-                    </span>
-                  </div>
-                  <div className="proxySplitGroupItemBottom">
-                    <span className="proxyTypeChip">{g.type}</span>
-                    <FlagMark iso2={selectedIso} width={12} height={9} />
-                    <span className="proxySplitGroupSelectedName">
-                      {nodeDisplayName(String(g.selected ?? '')) || '—'}
-                    </span>
-                  </div>
-                </button>
-              </li>
-            )
-          })}
-          {groupList.length === 0 ? (
-            <li className="muted small proxySplitEmpty">
-              {t('ui.proxies.noGroupMatch')}
-            </li>
-          ) : null}
-        </ul>
-      </aside>
+    <div className="proxyAccordion">
+      <div className="proxyAccFilterRow">
+        <input
+          type="text"
+          value={groupSearch}
+          onChange={(e) => setGroupSearch(e.target.value)}
+          placeholder={t('ui.proxies.searchGroup')}
+          className="inputModern proxyAccGroupSearch"
+          aria-label={t('ui.proxies.searchGroup')}
+        />
+      </div>
+      <div className="proxyAccList">
+        {shownGroups.map((g: any) => {
+          const name = String(g.name ?? '')
+          const isOpen = name === openName
+          const selected = String(g.selected ?? '')
+          const type = String(g.type ?? '')
+            .toLowerCase()
+            .replace(/-/g, '')
+          const isAuto =
+            type === 'urltest' || type === 'fallback' || type === 'loadbalance'
+          const allProxies = filterProxyNodesForDisplay(
+            (g.proxies ?? []) as string[],
+            showBuiltin,
+            selected,
+          )
+          const pingKey = `__all_${name}`
+          const selectedIso = extractNodeFlagIso(selected)
+          const health = groupHealth(allProxies, proxyDelayMap, proxyDelayErr)
 
-      <section className="proxySplitDetail">
-        {!focused ? (
-          <p className="muted">{t('ui.proxies.pickGroupHint')}</p>
-        ) : (
-          <>
-            <div className="proxySplitDetailHeader">
-              <div className="proxySplitDetailTitle">
-                <span className="proxySplitGroupName">
-                  {String(focused.name)}
+          let nodes = allProxies
+          if (isOpen) {
+            const q = nodeSearch.trim().toLowerCase()
+            if (q) {
+              nodes = nodes.filter(
+                (p) =>
+                  nodeDisplayName(p).toLowerCase().includes(q) ||
+                  p.toLowerCase().includes(q),
+              )
+            }
+            if (hideDead) nodes = nodes.filter((p) => !proxyDelayErr[p])
+            nodes = sortNodes(nodes)
+          }
+
+          return (
+            <div className={`proxyAccGroup${isOpen ? ' open' : ''}`} key={name}>
+              <button
+                type="button"
+                className="proxyAccHeader"
+                aria-expanded={isOpen}
+                onClick={() => setOpenName(isOpen ? '' : name)}
+              >
+                <span className="proxyAccName">{name}</span>
+                <span className={`proxyTypeChip proxyType-${type}`}>
+                  {g.type}
                 </span>
-                <span className="proxyTypeChip">{focused.type}</span>
                 <span className="proxyCountChip">
-                  {(focused.proxies ?? []).length}
+                  {(g.proxies ?? []).length}
                 </span>
-              </div>
-              <div className="proxySplitDetailTools">
-                <input
-                  type="text"
-                  value={nodeSearch}
-                  onChange={(e) => setNodeSearch(e.target.value)}
-                  placeholder={t('ui.proxies.searchNode')}
-                  className="inputModern proxySplitNodeSearch"
-                  aria-label={t('ui.proxies.searchNode')}
-                />
-                <button
-                  type="button"
-                  className="proxyToolbarIconBtn"
-                  disabled={
-                    connectionStatus !== 'connected' ||
-                    Boolean(proxyDelayBusy[focusedPingKey])
-                  }
-                  title={t('ui.proxies.pingAll')}
-                  aria-label={t('ui.proxies.pingAll')}
-                  onClick={() =>
-                    onPingAll(String(focused.name), focusedProxies)
-                  }
+                {health.best > 0 ? (
+                  <span
+                    className="proxyAccHealth"
+                    title={t('ui.proxies.healthTitle')}
+                  >
+                    {health.alive}/{health.total} · {health.best} ms
+                  </span>
+                ) : null}
+                <span className="proxyAccCurrent">
+                  <FlagMark iso2={selectedIso} width={12} height={9} />
+                  <span className="proxyAccCurrentName">
+                    {nodeDisplayName(selected) || '—'}
+                  </span>
+                </span>
+                <svg
+                  className="proxyAccChevron"
+                  viewBox="0 0 24 24"
+                  aria-hidden
                 >
-                  <svg
-                    className="proxyToolbarIcon"
-                    viewBox="0 0 24 24"
-                    aria-hidden
-                  >
-                    <path
-                      fill="currentColor"
-                      d="M11 21h-1l1-7H7.5c-.58 0-.57-.32-.38-.66.19-.34.05-.08.07-.12C8.48 10.94 10.42 7.54 13 3h1l-1 7h3.65c.58 0 .57.32.38.66-.19.34-.05.08-.07.12C14.52 13.06 12.58 16.46 10 21z"
-                    />
-                  </svg>
-                </button>
-              </div>
-            </div>
+                  <path
+                    fill="none"
+                    stroke="currentColor"
+                    strokeWidth="2"
+                    strokeLinecap="round"
+                    strokeLinejoin="round"
+                    d="M6 9l6 6 6-6"
+                  />
+                </svg>
+              </button>
 
-            {focusedIsAuto ? (
-              <p className="muted small proxyAutoGroupHint">
-                {t('ui.proxies.autoGroupHint')}
-              </p>
-            ) : null}
-
-            <div className="proxyNodesGrid proxySplitNodesGrid">
-              {filteredNodes.map((p: string) => {
-                const active = String(focused.selected ?? '') === p
-                const iso = extractNodeFlagIso(p)
-                const rawErr = proxyDelayErr[p]
-                const shortErr = shortProxyDelayError(rawErr)
-                const titleParts: string[] = []
-                if (focusedIsAuto)
-                  titleParts.push(t('ui.proxies.autoGroupHint'))
-                else titleParts.push(p)
-                if (rawErr) titleParts.push(String(rawErr))
-                return (
-                  <button
-                    key={p}
-                    type="button"
-                    className={`proxyNodeCard${active ? ' active' : ''}${focusedIsAuto ? ' proxyNodeDisabled' : ''}`}
-                    title={titleParts.join(' — ')}
-                    disabled={focusedIsAuto}
-                    onClick={() => {
-                      if (!p || active || focusedIsAuto) return
-                      onSelectNode(String(focused.name), p)
-                    }}
-                  >
-                    <div className="proxyNodeTop">
-                      <FlagMark iso2={iso} width={16} height={12} />
-                      <span className="proxyNodeName">
-                        {nodeDisplayName(p)}
+              {isOpen ? (
+                <div className="proxyAccBody">
+                  <div className="proxyAccActions">
+                    <button
+                      type="button"
+                      className="btn ghost proxyAccAction"
+                      disabled={!connected || Boolean(proxyDelayBusy[pingKey])}
+                      title={t('ui.proxies.pingAll')}
+                      onClick={() => onPingAll(name, allProxies)}
+                    >
+                      <span className="proxyAccActionEmoji" aria-hidden>
+                        📶
                       </span>
-                      <div className="proxyNodeTags">
-                        {nodeFeatureTags(p).map((tag) => (
-                          <span key={tag} className="proxyNodeTag">
-                            {tag}
-                          </span>
-                        ))}
-                      </div>
-                      <div className="proxyDelayBox proxyDelayBoxReadonly">
-                        <span
-                          className={`proxyDelayText${shortErr ? ' proxyDelayFail' : ''}`}
-                        >
-                          {proxyDelayBusy[p]
-                            ? '…'
-                            : shortErr
-                              ? shortErr
-                              : proxyDelayMap[p] > 0
-                                ? `${proxyDelayMap[p]} ms`
-                                : '—'}
+                      {t('ui.proxies.pingAllShort')}
+                    </button>
+                    {!isAuto ? (
+                      <button
+                        type="button"
+                        className="btn ghost proxyAccAction proxyAccFastest"
+                        title={t('ui.proxies.selectFastest')}
+                        disabled={
+                          !fastestNode(allProxies, proxyDelayMap, proxyDelayErr)
+                        }
+                        onClick={() => {
+                          const f = fastestNode(
+                            allProxies,
+                            proxyDelayMap,
+                            proxyDelayErr,
+                          )
+                          if (f && f !== selected) onSelectNode(name, f)
+                        }}
+                      >
+                        <span className="proxyAccActionEmoji" aria-hidden>
+                          ⚡
                         </span>
-                      </div>
-                    </div>
-                  </button>
-                )
-              })}
-              {filteredNodes.length === 0 ? (
-                <p className="muted small">{t('ui.proxies.noNodeMatch')}</p>
+                        {t('ui.proxies.fastest')}
+                      </button>
+                    ) : null}
+                    <select
+                      className="selectModern selectInline proxyAccSort"
+                      value={sortMode}
+                      onChange={(e) => setSortMode(e.target.value as SortMode)}
+                      aria-label={t('ui.proxies.sortLabel')}
+                    >
+                      <option value="default">
+                        {t('ui.proxies.sortDefault')}
+                      </option>
+                      <option value="latency">
+                        {t('ui.proxies.sortLatency')}
+                      </option>
+                      <option value="name">{t('ui.proxies.sortName')}</option>
+                    </select>
+                    <button
+                      type="button"
+                      className={`btn ghost proxyAccHideDead${hideDead ? ' isOn' : ''}`}
+                      aria-pressed={hideDead}
+                      onClick={() => setHideDead((v) => !v)}
+                    >
+                      {t('ui.proxies.hideDead')}
+                    </button>
+                    <button
+                      type="button"
+                      className="btn ghost proxyAccDensity"
+                      onClick={() =>
+                        setDensity((d) =>
+                          d === 'compact' ? 'comfortable' : 'compact',
+                        )
+                      }
+                      title={t('ui.proxies.density')}
+                    >
+                      {density === 'compact'
+                        ? t('ui.proxies.densityComfortable')
+                        : t('ui.proxies.densityCompact')}
+                    </button>
+                    <input
+                      type="text"
+                      value={nodeSearch}
+                      onChange={(e) => setNodeSearch(e.target.value)}
+                      placeholder={t('ui.proxies.searchNode')}
+                      className="inputModern proxySplitNodeSearch proxyAccSearch"
+                      aria-label={t('ui.proxies.searchNode')}
+                    />
+                  </div>
+
+                  {isAuto ? (
+                    <p className="muted small proxyAutoGroupHint">
+                      {t('ui.proxies.autoGroupHint')}
+                    </p>
+                  ) : null}
+
+                  <div
+                    className={`proxyNodesGrid${density === 'compact' ? ' compact' : ''}`}
+                  >
+                    {nodes.map((p: string) => {
+                      const active = selected === p
+                      const iso = extractNodeFlagIso(p)
+                      const rawErr = proxyDelayErr[p]
+                      const shortErr = shortProxyDelayError(rawErr)
+                      const ms = proxyDelayMap[p] ?? 0
+                      const band = delayBand(ms)
+                      const titleParts: string[] = []
+                      if (isAuto) titleParts.push(t('ui.proxies.autoGroupHint'))
+                      else titleParts.push(p)
+                      if (rawErr) titleParts.push(String(rawErr))
+                      return (
+                        <button
+                          key={p}
+                          type="button"
+                          ref={active ? activeCardRef : undefined}
+                          className={`proxyNodeCard${active ? ' active' : ''}${isAuto ? ' proxyNodeDisabled' : ''}`}
+                          title={titleParts.join(' — ')}
+                          disabled={isAuto}
+                          onClick={() => {
+                            if (!p || active || isAuto) return
+                            onSelectNode(name, p)
+                          }}
+                        >
+                          <div className="proxyNodeTop">
+                            <FlagMark iso2={iso} width={16} height={12} />
+                            <span className="proxyNodeName">
+                              {nodeDisplayName(p)}
+                            </span>
+                            <div className="proxyNodeTags">
+                              {nodeFeatureTags(p).map((tag) => (
+                                <span key={tag} className="proxyNodeTag">
+                                  {tag}
+                                </span>
+                              ))}
+                            </div>
+                            <div className="proxyDelayBox proxyDelayBoxReadonly">
+                              <span
+                                className={`proxyDelayText${shortErr ? ' proxyDelayFail' : band ? ` proxyDelay${band[0].toUpperCase()}${band.slice(1)}` : ''}`}
+                              >
+                                {proxyDelayBusy[p]
+                                  ? '…'
+                                  : shortErr
+                                    ? shortErr
+                                    : ms > 0
+                                      ? `${ms} ms`
+                                      : '—'}
+                              </span>
+                            </div>
+                          </div>
+                          {band ? (
+                            <span
+                              className={`proxyDelayBar proxyDelayBar${band[0].toUpperCase()}${band.slice(1)}`}
+                              aria-hidden
+                            >
+                              <span
+                                className="proxyDelayBarFill"
+                                style={{ width: `${delayBarPct(ms)}%` }}
+                              />
+                            </span>
+                          ) : null}
+                        </button>
+                      )
+                    })}
+                    {nodes.length === 0 ? (
+                      <p className="muted small">
+                        {t('ui.proxies.noNodeMatch')}
+                      </p>
+                    ) : null}
+                  </div>
+                </div>
               ) : null}
             </div>
-          </>
-        )}
-      </section>
+          )
+        })}
+        {shownGroups.length === 0 ? (
+          <p className="muted small proxyAccEmpty">
+            {t('ui.proxies.noGroupMatch')}
+          </p>
+        ) : null}
+      </div>
     </div>
   )
 }


### PR DESCRIPTION
Reworks the Proxies screen from a two-pane split into a single-open accordion.

- **Accordion:** group rows expand inline; only one open at a time; nodes scroll
  inside the open section so the page never scrolls.
- **Speed:** auto-test on expand, "⚡ Fastest" (pick the fastest live node),
  per-group health in the row (alive/total · best latency), latency colour
  bands + bars.
- **Controls:** group quick-filter, sort (default/latency/name), hide-dead,
  density toggle; open group / sort / filters persist across sessions.
- **Type chips:** per-type colours (url-test=emerald, selector=purple,
  fallback=turquoise, load-balance=olive — no blue) in a mono face.
- Emoji-labelled actions; fixed a stray focus-outline stripe.

Frontend only; no backend/binding changes.
