### PR TITLE
feat(ui): rework Edit rules modal + full rule-type set + themed scrollbars

### DIFF
--- a/apps/sloth-clash-desktop/frontend/src/App.css
+++ b/apps/sloth-clash-desktop/frontend/src/App.css
@@ -66,6 +66,9 @@
   --dur-base: 200ms;
   --dur-slow: 320ms;
   --ease-standard: cubic-bezier(0.4, 0, 0.2, 1);
+  /* scrollbars — themed (bronze) instead of stark white */
+  --scrollbar-thumb: rgba(201, 168, 108, 0.3);
+  --scrollbar-thumb-hover: rgba(201, 168, 108, 0.5);
 
   background: radial-gradient(
     circle at 18% 10%,
@@ -244,12 +247,46 @@
   --text-muted: #6f6450;
   --hairline: rgba(70, 52, 28, 0.1);
   --hairline-strong: rgba(70, 52, 28, 0.16);
+  --scrollbar-thumb: rgba(147, 107, 56, 0.34);
+  --scrollbar-thumb-hover: rgba(147, 107, 56, 0.55);
   background: radial-gradient(
     circle at 18% 10%,
     #f2ebdc 0,
     #e9dec8 50%,
     #ddccb0 100%
   );
+}
+
+/* Themed scrollbars everywhere inside the app (WebView2 / Chromium) so they
+   blend with the palette instead of the stark default white bar. */
+.shell {
+  scrollbar-width: thin;
+  scrollbar-color: var(--scrollbar-thumb) transparent;
+}
+
+.shell ::-webkit-scrollbar {
+  width: 10px;
+  height: 10px;
+}
+
+.shell ::-webkit-scrollbar-track {
+  background: transparent;
+}
+
+.shell ::-webkit-scrollbar-thumb {
+  background: var(--scrollbar-thumb);
+  border-radius: var(--radius-pill);
+  border: 2px solid transparent;
+  background-clip: padding-box;
+}
+
+.shell ::-webkit-scrollbar-thumb:hover {
+  background: var(--scrollbar-thumb-hover);
+  background-clip: padding-box;
+}
+
+.shell ::-webkit-scrollbar-corner {
+  background: transparent;
 }
 
 .shell[data-theme="light"] .nav {
@@ -3582,6 +3619,185 @@
   max-height: 94vh;
   min-height: min(84vh, 760px);
   overflow: auto;
+}
+
+/* === Edit rules — compact add-bar + two columns (rules-editor-rework) === */
+.rulesEditorModal {
+  display: flex;
+  flex-direction: column;
+  overflow: hidden;
+}
+
+.rulesEditorModal > .vergeModalHead,
+.rulesEditorModal > .modalFooter,
+.rulesEditorModal > .rulesAdvancedField {
+  flex: 0 0 auto;
+}
+
+.rulesEditorBody {
+  flex: 1 1 auto;
+  min-height: 0;
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-3);
+}
+
+.rulesAddBar {
+  flex: 0 0 auto;
+  display: flex;
+  flex-wrap: wrap;
+  align-items: center;
+  gap: var(--space-2);
+  padding: var(--space-2);
+  border: 1px solid var(--hairline);
+  border-radius: var(--radius-md);
+  background: rgba(0, 0, 0, 0.12);
+}
+
+.shell[data-theme="light"] .rulesAddBar {
+  background: rgba(74, 55, 30, 0.04);
+}
+
+.rulesAddType {
+  flex: 0 0 auto;
+  width: auto;
+  min-width: 150px;
+  max-width: 190px;
+}
+
+.rulesAddContent {
+  flex: 1 1 160px;
+  min-width: 120px;
+}
+
+.rulesAddArrow {
+  flex: 0 0 auto;
+  color: var(--text-muted);
+}
+
+.rulesAddPolicy {
+  flex: 0 0 auto;
+  width: auto;
+  min-width: 130px;
+  max-width: 180px;
+}
+
+.rulesAddPos {
+  flex: 0 0 auto;
+}
+
+.rulesAddBtn {
+  flex: 0 0 auto;
+  white-space: nowrap;
+}
+
+.rulesCols {
+  flex: 1 1 auto;
+  min-height: 0;
+  display: grid;
+  grid-template-columns: 1fr 1fr;
+  gap: var(--space-3);
+}
+
+@media (max-width: 760px) {
+  .rulesCols {
+    grid-template-columns: 1fr;
+  }
+}
+
+.rulesCol {
+  display: flex;
+  flex-direction: column;
+  min-height: 0;
+}
+
+.rulesCol > .eyebrow {
+  flex: 0 0 auto;
+  margin: 0 0 var(--space-2);
+}
+
+.rulesList {
+  flex: 1 1 auto;
+  min-height: 0;
+  overflow-y: auto;
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-1);
+  padding-right: var(--space-1);
+}
+
+.ruleRow {
+  display: flex;
+  align-items: center;
+  gap: var(--space-2);
+  padding: var(--space-1) var(--space-2);
+  border: 1px solid var(--hairline);
+  border-radius: var(--radius-sm);
+  background: rgba(0, 0, 0, 0.12);
+  font-size: var(--font-size-sm);
+}
+
+.shell[data-theme="light"] .ruleRow {
+  background: rgba(74, 55, 30, 0.04);
+}
+
+.ruleRowDeleted {
+  opacity: 0.5;
+  text-decoration: line-through;
+}
+
+.ruleTypeChip {
+  flex: 0 0 auto;
+  font-family: var(--font-mono);
+  font-size: var(--font-size-xs);
+  letter-spacing: 0.04em;
+  padding: 1px 6px;
+  border-radius: var(--radius-pill);
+  background: rgba(150, 150, 150, 0.14);
+  border: 1px solid rgba(150, 150, 150, 0.3);
+  color: var(--text-muted);
+  white-space: nowrap;
+}
+
+.ruleContent {
+  flex: 1 1 auto;
+  min-width: 0;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.ruleArrow {
+  flex: 0 0 auto;
+  color: var(--text-muted);
+}
+
+.rulePolicy {
+  flex: 0 0 auto;
+  max-width: 130px;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+  font-weight: var(--weight-medium);
+  color: var(--accent);
+}
+
+.rulePos {
+  flex: 0 0 auto;
+  font-size: var(--font-size-xs);
+  color: var(--text-muted);
+  text-transform: uppercase;
+  letter-spacing: 0.04em;
+}
+
+.ruleRemove {
+  flex: 0 0 auto;
+  padding: 0 var(--space-2);
+  line-height: 1.4;
+}
+
+.rulesYamlErr {
+  color: var(--danger);
 }
 
 .yamlModalBlurb {

--- a/apps/sloth-clash-desktop/frontend/src/components/ProfileRulesModal.tsx
+++ b/apps/sloth-clash-desktop/frontend/src/components/ProfileRulesModal.tsx
@@ -22,6 +22,52 @@ import type { ProfileModalTarget } from './ProfileMergeModal'
 type Mode = 'visual' | 'advanced'
 type RuleAppendTarget = 'prepend' | 'append'
 
+// One-line read/edit row used in both columns.
+function RuleLine({
+  ruleType,
+  content,
+  policy,
+  pos,
+  deleted,
+  actionLabel,
+  actionGlyph,
+  onAction,
+}: {
+  ruleType: string
+  content: string
+  policy: string
+  pos?: RuleAppendTarget
+  deleted?: boolean
+  actionLabel: string
+  actionGlyph: string
+  onAction: () => void
+}) {
+  return (
+    <div className={`ruleRow${deleted ? ' ruleRowDeleted' : ''}`}>
+      <span className="ruleTypeChip">{ruleType}</span>
+      <span className="ruleContent" title={content}>
+        {content || '—'}
+      </span>
+      <span className="ruleArrow" aria-hidden>
+        →
+      </span>
+      <span className="rulePolicy" title={policy}>
+        {policy}
+      </span>
+      {pos ? <span className="rulePos">{pos}</span> : null}
+      <button
+        type="button"
+        className="btn ghost ruleRemove"
+        aria-label={actionLabel}
+        title={actionLabel}
+        onClick={onAction}
+      >
+        {actionGlyph}
+      </button>
+    </div>
+  )
+}
+
 export function ProfileRulesModal({
   target,
   profiles,
@@ -37,9 +83,6 @@ export function ProfileRulesModal({
   onSaved: (banner: string) => void
   onError: (msg: string) => void
 }) {
-  // Drafts are derived from the active target on first mount.
-  // App.tsx passes `key={target?.id}` so a new target triggers a remount and
-  // these lazy initializers run again.
   const initialRaw = target ? rulesTemplateFromProfile(profiles, target.id) : ''
   const initialBuckets = useMemo(
     () => rulesBucketsFromMerge(initialRaw),
@@ -169,11 +212,7 @@ export function ProfileRulesModal({
   const removeAppendRow = (rowId: string) => {
     const next = appendRows.filter((x) => x.id !== rowId)
     setAppendRows(next)
-    const buckets = {
-      prepend: rows,
-      append: next,
-      delete: deletedBaseline,
-    }
+    const buckets = { prepend: rows, append: next, delete: deletedBaseline }
     setMergeDraft((prev) => applyRulesBucketsToMerge(prev, buckets))
     setAdvancedDraft(rulesBucketsToAdvancedYaml(buckets))
   }
@@ -184,11 +223,7 @@ export function ProfileRulesModal({
       ? deletedBaseline.filter((x) => x !== line)
       : [...deletedBaseline, line]
     setDeletedBaseline(nextDel)
-    const buckets = {
-      prepend: rows,
-      append: appendRows,
-      delete: nextDel,
-    }
+    const buckets = { prepend: rows, append: appendRows, delete: nextDel }
     setMergeDraft((prev) => applyRulesBucketsToMerge(prev, buckets))
     setAdvancedDraft(rulesBucketsToAdvancedYaml(buckets))
   }
@@ -214,6 +249,8 @@ export function ProfileRulesModal({
     }
   }
 
+  const hasCustom = rows.length > 0 || appendRows.length > 0
+
   return (
     <div
       className="modalOverlay"
@@ -222,7 +259,7 @@ export function ProfileRulesModal({
       onClick={onClose}
     >
       <div
-        className={`modalCard modalCardWide yamlModalCard vergeModal ${
+        className={`modalCard modalCardWide rulesEditorModal ${
           uiMode === 'advanced' ? 'modalCardFullscreen' : 'modalCardVisualTall'
         }`}
         role="dialog"
@@ -251,193 +288,158 @@ export function ProfileRulesModal({
             </button>
           </div>
         </div>
-        <div
-          className={`vergeSplit ${
-            uiMode === 'advanced' ? 'vergeSplitAdvanced' : ''
-          }`}
-        >
-          <div className="vergePane">
-            {uiMode === 'visual' ? (
-              <>
-                <label className="field modalField">
-                  <span className="fieldLab">Rule type</span>
-                  <select
-                    className="selectModern"
-                    value={formType}
-                    onChange={(e) => setFormType(e.target.value)}
-                  >
-                    {RULE_TYPE_OPTIONS.map((type) => (
-                      <option key={type} value={type}>
-                        {type}
-                      </option>
-                    ))}
-                  </select>
-                </label>
-                <label className="field modalField">
-                  <span className="fieldLab">Rule content</span>
-                  <input
-                    className="input"
-                    value={formContent}
-                    onChange={(e) => setFormContent(e.target.value)}
-                    placeholder="google.com"
-                  />
-                </label>
-                <label className="field modalField">
-                  <span className="fieldLab">Proxy policy</span>
-                  <select
-                    className="selectModern"
-                    value={formPolicy}
-                    onChange={(e) => setFormPolicy(e.target.value)}
-                  >
-                    {policyOptions.map((opt) => (
-                      <option key={opt} value={opt}>
-                        {opt}
-                      </option>
-                    ))}
-                  </select>
-                </label>
-                <div className="vergeRuleActions">
-                  <div className="segPill">
-                    <button
-                      type="button"
-                      className={`pillOpt ${appendTarget === 'prepend' ? 'active' : ''}`}
-                      onClick={() => setAppendTarget('prepend')}
-                    >
-                      Prepend
-                    </button>
-                    <button
-                      type="button"
-                      className={`pillOpt ${appendTarget === 'append' ? 'active' : ''}`}
-                      onClick={() => setAppendTarget('append')}
-                    >
-                      Append
-                    </button>
-                  </div>
-                  <button
-                    type="button"
-                    className="btn primary vergeStackBtn"
-                    onClick={addRule}
-                  >
-                    Add rule
-                  </button>
+
+        {uiMode === 'advanced' ? (
+          <label className="field modalField rulesAdvancedField">
+            <span className="fieldLab">Advanced YAML</span>
+            <MonacoYamlEditor
+              className="vergePaneYaml modalMonacoWrap"
+              value={advancedDraft}
+              onChange={setAdvancedDraft}
+              height="56vh"
+            />
+            {advancedYamlErr ? (
+              <span className="rulesYamlErr small">
+                YAML error: {advancedYamlErr}
+              </span>
+            ) : null}
+          </label>
+        ) : (
+          <div className="rulesEditorBody">
+            <div className="rulesAddBar">
+              <select
+                className="selectModern selectInline rulesAddType"
+                value={formType}
+                onChange={(e) => setFormType(e.target.value)}
+                aria-label="Rule type"
+              >
+                {RULE_TYPE_OPTIONS.map((type) => (
+                  <option key={type} value={type}>
+                    {type}
+                  </option>
+                ))}
+              </select>
+              <input
+                className="input rulesAddContent"
+                value={formContent}
+                onChange={(e) => setFormContent(e.target.value)}
+                placeholder={
+                  formType === 'MATCH' ? '(no content)' : 'google.com'
+                }
+                disabled={formType === 'MATCH'}
+                onKeyDown={(e) => {
+                  if (e.key === 'Enter') addRule()
+                }}
+              />
+              <span className="rulesAddArrow" aria-hidden>
+                →
+              </span>
+              <select
+                className="selectModern selectInline rulesAddPolicy"
+                value={formPolicy}
+                onChange={(e) => setFormPolicy(e.target.value)}
+                aria-label="Proxy policy"
+              >
+                {policyOptions.map((opt) => (
+                  <option key={opt} value={opt}>
+                    {opt}
+                  </option>
+                ))}
+              </select>
+              <div className="segPill rulesAddPos">
+                <button
+                  type="button"
+                  className={`pillOpt ${appendTarget === 'prepend' ? 'active' : ''}`}
+                  onClick={() => setAppendTarget('prepend')}
+                >
+                  Prepend
+                </button>
+                <button
+                  type="button"
+                  className={`pillOpt ${appendTarget === 'append' ? 'active' : ''}`}
+                  onClick={() => setAppendTarget('append')}
+                >
+                  Append
+                </button>
+              </div>
+              <button
+                type="button"
+                className="btn primary rulesAddBtn"
+                onClick={addRule}
+              >
+                + Add
+              </button>
+            </div>
+
+            <div className="rulesCols">
+              <div className="rulesCol">
+                <p className="eyebrow">Your rules</p>
+                <div className="rulesList">
+                  {!hasCustom ? (
+                    <p className="muted small">No custom rules yet.</p>
+                  ) : null}
+                  {rows.map((r) => (
+                    <RuleLine
+                      key={r.id}
+                      ruleType={r.ruleType}
+                      content={r.content}
+                      policy={r.policy}
+                      pos="prepend"
+                      actionLabel="Remove"
+                      actionGlyph="×"
+                      onAction={() => removeRow(r.id)}
+                    />
+                  ))}
+                  {appendRows.map((r) => (
+                    <RuleLine
+                      key={r.id}
+                      ruleType={r.ruleType}
+                      content={r.content}
+                      policy={r.policy}
+                      pos="append"
+                      actionLabel="Remove"
+                      actionGlyph="×"
+                      onAction={() => removeAppendRow(r.id)}
+                    />
+                  ))}
                 </div>
-              </>
-            ) : (
-              <label className="field modalField">
-                <span className="fieldLab">Advanced YAML</span>
-                <MonacoYamlEditor
-                  className="vergePaneYaml modalMonacoWrap"
-                  value={advancedDraft}
-                  onChange={setAdvancedDraft}
-                  height="52vh"
-                />
-                {advancedYamlErr ? (
-                  <span className="muted small" style={{ color: '#ff6b6b' }}>
-                    YAML error: {advancedYamlErr}
-                  </span>
-                ) : null}
-              </label>
-            )}
-          </div>
-          {uiMode === 'visual' ? (
-            <div className="vergePane vergePaneList">
-              <p className="eyebrow">subscription.rules</p>
-              <div className="vergeScrollList">
-                {baselineLoading ? (
-                  <p className="muted small">Loading subscription rules…</p>
-                ) : baselineError ? (
-                  <p className="muted small" style={{ color: '#ff6b6b' }}>
-                    {baselineError}
-                  </p>
-                ) : !baseline || baseline.length === 0 ? (
-                  <p className="muted small">No subscription rules detected.</p>
-                ) : (
-                  baseline.map((line, idx) => {
-                    const parsed = parseRuleLine(line, idx)
-                    const isDeleted = deletedBaseline.includes(line)
-                    return (
-                      <div
-                        key={parsed.id}
-                        className={`vergeCard vergeCardReadOnly ${
-                          isDeleted ? 'vergeCardDeleted' : ''
-                        }`}
-                      >
-                        <div>
-                          <div className="vergeCardTitle">
-                            {parsed.ruleType}
-                          </div>
-                          <div className="muted small">{parsed.content}</div>
-                          <div className="muted small">→ {parsed.policy}</div>
-                        </div>
-                        <button
-                          type="button"
-                          className="btn ghost vergeTrash"
-                          aria-label={isDeleted ? 'Restore' : 'Delete'}
-                          title={isDeleted ? 'Restore' : 'Delete'}
-                          onClick={() => toggleBaselineDelete(line)}
-                        >
-                          {isDeleted ? '↺' : '×'}
-                        </button>
-                      </div>
-                    )
-                  })
-                )}
               </div>
-              <p className="eyebrow" style={{ marginTop: 10 }}>
-                prepend.rules
-              </p>
-              <div className="vergeScrollList">
-                {rows.length === 0 ? (
-                  <p className="muted small">No custom prepend rules.</p>
-                ) : (
-                  rows.map((r) => (
-                    <div key={r.id} className="vergeCard">
-                      <div>
-                        <div className="vergeCardTitle">{r.ruleType}</div>
-                        <div className="muted small">{r.content}</div>
-                        <div className="muted small">→ {r.policy}</div>
-                      </div>
-                      <button
-                        type="button"
-                        className="btn ghost vergeTrash"
-                        aria-label="Remove"
-                        onClick={() => removeRow(r.id)}
-                      >
-                        ×
-                      </button>
-                    </div>
-                  ))
-                )}
-              </div>
-              <p className="eyebrow" style={{ marginTop: 10 }}>
-                append.rules
-              </p>
-              <div className="vergeScrollList">
-                {appendRows.length === 0 ? (
-                  <p className="muted small">No custom append rules.</p>
-                ) : (
-                  appendRows.map((r) => (
-                    <div key={r.id} className="vergeCard">
-                      <div>
-                        <div className="vergeCardTitle">{r.ruleType}</div>
-                        <div className="muted small">{r.content}</div>
-                        <div className="muted small">→ {r.policy}</div>
-                      </div>
-                      <button
-                        type="button"
-                        className="btn ghost vergeTrash"
-                        aria-label="Remove"
-                        onClick={() => removeAppendRow(r.id)}
-                      >
-                        ×
-                      </button>
-                    </div>
-                  ))
-                )}
+
+              <div className="rulesCol">
+                <p className="eyebrow">Subscription · read-only</p>
+                <div className="rulesList">
+                  {baselineLoading ? (
+                    <p className="muted small">Loading subscription rules…</p>
+                  ) : baselineError ? (
+                    <p className="muted small rulesYamlErr">{baselineError}</p>
+                  ) : !baseline || baseline.length === 0 ? (
+                    <p className="muted small">
+                      No subscription rules detected.
+                    </p>
+                  ) : (
+                    baseline.map((line, idx) => {
+                      const parsed = parseRuleLine(line, idx)
+                      const isDeleted = deletedBaseline.includes(line)
+                      return (
+                        <RuleLine
+                          key={parsed.id}
+                          ruleType={parsed.ruleType}
+                          content={parsed.content}
+                          policy={parsed.policy}
+                          deleted={isDeleted}
+                          actionLabel={isDeleted ? 'Restore' : 'Delete'}
+                          actionGlyph={isDeleted ? '↺' : '×'}
+                          onAction={() => toggleBaselineDelete(line)}
+                        />
+                      )
+                    })
+                  )}
+                </div>
               </div>
             </div>
-          ) : null}
-        </div>
+          </div>
+        )}
+
         <div className="modalFooter">
           <button type="button" className="btn ghost" onClick={onClose}>
             Cancel

--- a/apps/sloth-clash-desktop/frontend/src/constants.ts
+++ b/apps/sloth-clash-desktop/frontend/src/constants.ts
@@ -5,20 +5,49 @@ export const LS_SETTINGS = 'sloth-settings-v1'
 
 export const APP_REPO_URL = 'https://github.com/Nemu-x/SlothClash'
 
+// Full mihomo (Clash.Meta) rule-type set, grouped: domain / IP / source-IP /
+// port / process / inbound / misc / rule-set & logical / MATCH last.
 export const RULE_TYPE_OPTIONS = [
+  // domain
   'DOMAIN-SUFFIX',
   'DOMAIN',
   'DOMAIN-KEYWORD',
   'DOMAIN-REGEX',
-  'MATCH',
   'GEOSITE',
-  'GEOIP',
+  // destination IP
   'IP-CIDR',
   'IP-CIDR6',
+  'IP-SUFFIX',
+  'IP-ASN',
+  'GEOIP',
+  // source IP
   'SRC-IP-CIDR',
+  'SRC-IP-SUFFIX',
+  'SRC-GEOIP',
+  'SRC-IP-ASN',
+  // port
   'DST-PORT',
   'SRC-PORT',
+  'IN-PORT',
+  // process
   'PROCESS-NAME',
   'PROCESS-PATH',
+  'PROCESS-NAME-REGEX',
+  'PROCESS-PATH-REGEX',
+  // inbound / user
+  'IN-TYPE',
+  'IN-USER',
+  'IN-NAME',
+  'UID',
+  // misc
   'NETWORK',
+  'DSCP',
+  // rule providers & logical
+  'RULE-SET',
+  'AND',
+  'OR',
+  'NOT',
+  'SUB-RULE',
+  // catch-all
+  'MATCH',
 ] as const


### PR DESCRIPTION
Edit rules: single-line add-bar (type/content/policy/prepend-append/add) and a two-column layout (Your rules | read-only Subscription); rules render as compact one-line rows with a mono type chip; modal is a flex column with internally-scrolling lists. Expand RULE_TYPE_OPTIONS to the full mihomo set (domain/IP/src-IP/port/process/inbound/network/dscp/rule-set/AND-OR-NOT/SUB-RULE/MATCH). Theme the scrollbars (bronze, both themes) via ::-webkit-scrollbar + scrollbar-color instead of the stark default white.