### PR TITLE
fix(core): tear down core+TUN before update, settle adapter before kill

### DIFF
--- a/apps/sloth-clash-desktop/app.go
+++ b/apps/sloth-clash-desktop/app.go
@@ -199,11 +199,23 @@ func (a *App) shutdown(ctx context.Context) {
 	// makes the tray "flicker" away while the app is still running.
 	a.connectGen.Add(1)
 
-	// Before we tear down Mihomo, ask it to disable TUN via PATCH /configs.
-	// Without this step the process is killed while TUN is still bound, which
-	// on macOS can leave the utun adapter in an "on" zombie state that the UI
-	// cannot reliably clean up next launch. On Windows the same PATCH lets
-	// wintun unwind cleanly instead of relying on abrupt process teardown.
+	a.drainTunAndStopCore()
+}
+
+// tunDrainSettle is how long we wait after asking mihomo to disable TUN before
+// killing the core, giving it time to fully remove the wintun/utun adapter.
+const tunDrainSettle = 1200 * time.Millisecond
+
+// drainTunAndStopCore disables TUN via the core (so the wintun/utun adapter
+// unwinds cleanly) and then stops the core. Used on graceful shutdown and before
+// an in-app update launches the installer.
+//
+// Without the TUN drain the process is killed while TUN is still bound, which on
+// macOS can leave the utun adapter in an "on" zombie state and on Windows leaves
+// wintun up. The in-app updater's installer kills this process to replace it,
+// bypassing shutdown(); if the core (and its TUN adapter) survive the update, the
+// next launch's first Connect hits an already-up TUN. See fix-tun-teardown-on-update.
+func (a *App) drainTunAndStopCore() {
 	a.mu.RLock()
 	listen := a.effectiveCoreEndpointLocked()
 	secret := a.coreSecret
@@ -213,6 +225,11 @@ func (a *App) shutdown(ctx context.Context) {
 		dctx, dcancel := context.WithTimeout(context.Background(), 3*time.Second)
 		_ = coreSetTunEnabledAt(dctx, listen, secret, false)
 		dcancel()
+		// Let mihomo actually remove the wintun/utun adapter before we kill the
+		// core. Without this settle the kill interrupts adapter teardown and the
+		// device lingers (the "Meta" adapter stays up in Network Connections),
+		// which trips the next launch's first Connect after a fast in-app update.
+		time.Sleep(tunDrainSettle)
 	}
 
 	a.mu.Lock()

--- a/apps/sloth-clash-desktop/app_update.go
+++ b/apps/sloth-clash-desktop/app_update.go
@@ -24,12 +24,12 @@ const (
 	githubOwner = "Nemu-x"
 	githubRepo  = "SlothClash"
 
-	githubAPIHTTPTimeout   = 45 * time.Second
+	githubAPIHTTPTimeout  = 45 * time.Second
 	updateDownloadTimeout = 60 * time.Minute
 )
 
 var (
-	githubAPIHTTPClient       = &http.Client{Timeout: githubAPIHTTPTimeout}
+	githubAPIHTTPClient      = &http.Client{Timeout: githubAPIHTTPTimeout}
 	updateDownloadHTTPClient = &http.Client{Timeout: updateDownloadTimeout}
 )
 
@@ -400,6 +400,13 @@ func (a *App) ApplyUpdate() error {
 			"reason": "no checksums file published",
 		})
 	}
+
+	// Tear down the core + TUN before handing off to the installer. The installer
+	// kills this process to replace it, bypassing the normal shutdown() path; without
+	// this the core (and its wintun adapter) survive the update and the next launch's
+	// first Connect hits an already-up TUN. See fix-tun-teardown-on-update.
+	a.traceEvent("update.teardown", "core+tun", 0, nil)
+	a.drainTunAndStopCore()
 
 	cmd := exec.Command(tmp)
 	if attr := hideWindowSysProcAttr(); attr != nil {


### PR DESCRIPTION
The in-app updater launched the installer without stopping the core, so the installer killed the app bypassing shutdown() — leaving the mihomo core and its wintun adapter up; the next launch's first Connect then hit an already-up TUN. Extract a shared drainTunAndStopCore() (disable TUN via the core, then stopCoreLocked) and call it from shutdown() and ApplyUpdate() before the installer launch. Add a 1.2s settle between disabling TUN and killing the core so mihomo finishes removing the wintun/utun adapter.