### PR TITLE
ci: add security gating (govulncheck + pnpm audit), move off EOL Go 1.23

### DIFF
--- a/.github/workflows/desktop-artifacts.yml
+++ b/.github/workflows/desktop-artifacts.yml
@@ -25,7 +25,7 @@ jobs:
 
       - uses: actions/setup-go@v5
         with:
-          go-version: '1.23.x'
+          go-version: '1.26.x'
           cache: true
           cache-dependency-path: apps/sloth-clash-desktop/go.sum
 
@@ -87,7 +87,7 @@ jobs:
 
       - uses: actions/setup-go@v5
         with:
-          go-version: '1.23.x'
+          go-version: '1.26.x'
           cache: true
           cache-dependency-path: apps/sloth-clash-desktop/go.sum
 
@@ -153,7 +153,7 @@ jobs:
 
       - uses: actions/setup-go@v5
         with:
-          go-version: '1.23.x'
+          go-version: '1.26.x'
           cache: true
           cache-dependency-path: apps/sloth-clash-desktop/go.sum
 
@@ -195,7 +195,7 @@ jobs:
 
       - uses: actions/setup-go@v5
         with:
-          go-version: '1.23.x'
+          go-version: '1.26.x'
           cache: true
           cache-dependency-path: apps/sloth-clash-desktop/go.sum
 
@@ -246,7 +246,7 @@ jobs:
 
       - uses: actions/setup-go@v5
         with:
-          go-version: '1.23.x'
+          go-version: '1.26.x'
           cache: true
           cache-dependency-path: apps/sloth-clash-desktop/go.sum
 

--- a/.github/workflows/integration-preflight.yml
+++ b/.github/workflows/integration-preflight.yml
@@ -48,7 +48,7 @@ jobs:
 
       - uses: actions/setup-go@v5
         with:
-          go-version: '1.23.x'
+          go-version: '1.26.x'
           cache: true
           cache-dependency-path: apps/sloth-clash-desktop/go.sum
 

--- a/.github/workflows/required-tests.yml
+++ b/.github/workflows/required-tests.yml
@@ -20,7 +20,7 @@ jobs:
 
       - uses: actions/setup-go@v5
         with:
-          go-version: '1.23.x'
+          go-version: '1.26.x'
           cache: true
           cache-dependency-path: apps/sloth-clash-desktop/go.sum
 

--- a/.github/workflows/security-audit.yml
+++ b/.github/workflows/security-audit.yml
@@ -1,0 +1,49 @@
+# Security gating (audit finding F4): fail PRs/pushes on known vulnerabilities.
+#   - Go: govulncheck (only fails on vulns the code actually *calls*).
+#   - Frontend: pnpm audit on production deps (fail on high+).
+name: Security audit
+
+on:
+  pull_request:
+  push:
+    branches:
+      - init/SlothClash
+  schedule:
+    - cron: '0 6 * * 1' # weekly, Monday 06:00 UTC
+
+permissions:
+  contents: read
+
+concurrency:
+  group: security-audit-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  go-vuln:
+    name: govulncheck (Go)
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-go@v5
+        with:
+          go-version: '1.26.x'
+          cache: true
+          cache-dependency-path: apps/sloth-clash-desktop/go.sum
+      - name: govulncheck
+        working-directory: apps/sloth-clash-desktop
+        run: go run golang.org/x/vuln/cmd/govulncheck@latest ./...
+
+  frontend-audit:
+    name: pnpm audit (frontend prod deps)
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: pnpm/action-setup@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: '20'
+          cache: pnpm
+      - name: Install dependencies
+        run: pnpm install --frozen-lockfile
+      - name: pnpm audit (prod, fail on high+)
+        run: pnpm audit --prod --audit-level high

--- a/apps/sloth-clash-desktop/go.mod
+++ b/apps/sloth-clash-desktop/go.mod
@@ -1,6 +1,7 @@
 module SlothClashDesktop
 
 go 1.23.0
+toolchain go1.26.4
 
 require (
 	github.com/Microsoft/go-winio v0.6.2


### PR DESCRIPTION
Add .github/workflows/security-audit.yml running govulncheck ./... (Go, fails only on called vulns) and pnpm audit --prod --audit-level high (frontend) on PR/push/weekly, both blocking (closes audit F4). govulncheck showed the only reachable vulnerabilities were in the Go standard library because the project built on EOL Go 1.23; pin toolchain go1.26.4 in go.mod and bump CI setup-go to 1.26.x -> 0 called vulnerabilities (resolves the security-relevant part of F5; remaining stale third-party modules are not reachable and are deferred).