### PR TITLE
chore(release): bump to 0.6.0

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -1,4 +1,4 @@
-## Unreleased
+## Sloth Clash desktop `0.6.0` — 2026-06-06
 
 ### English
 

--- a/apps/sloth-clash-desktop/version.go
+++ b/apps/sloth-clash-desktop/version.go
@@ -1,4 +1,4 @@
 package main
 
 // AppVersion must match wails.json info.productVersion (X.Y.Z) for update checks.
-const AppVersion = "0.5.1"
+const AppVersion = "0.6.0"

--- a/apps/sloth-clash-desktop/wails.json
+++ b/apps/sloth-clash-desktop/wails.json
@@ -13,7 +13,7 @@
   "info": {
     "companyName": "Nemu-x",
     "productName": "Sloth Clash",
-    "productVersion": "0.5.1",
+    "productVersion": "0.6.0",
     "copyright": "GPL-3.0",
     "comments": "https://github.com/Nemu-x/SlothClash",
     "protocols": [

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "sloth-clash",
-  "version": "0.5.1",
+  "version": "0.6.0",
   "license": "GPL-3.0-only",
   "scripts": {
     "prepare": "husky || true",


### PR DESCRIPTION
Bump app version to 0.6.0 (version.go AppVersion, wails.json productVersion, root package.json) and promote the Unreleased changelog section to the 0.6.0 release (core 1.19.26 pin, frontend vuln clears, local-config/share-link import, signed fail-closed in-app updates + progress/changelog/auto-update toggle, TUN-teardown-on-update fix, visual polish across Proxies/Rules/Advanced/Settings, switch toggles, two-column layouts, themed scrollbars, CI security gating + Go 1.26 toolchain, dependency bumps, NSIS redist progress, adjustable interface scale).