### PR TITLE
chore(core): bump pinned mihomo core to v1.19.27

### DIFF
--- a/scripts/prebuild.mjs
+++ b/scripts/prebuild.mjs
@@ -165,7 +165,7 @@ async function updateHashCache(targetPath) {
 // Pinned mihomo (Clash.Meta) core version — single source of truth.
 // To bump: edit this constant, then run `pnpm run prebuild --force` to refresh
 // the embedded sidecar. Override at build time with MIHOMO_CORE_VERSION (CI/testing).
-const META_VERSION_PINNED = 'v1.19.26'
+const META_VERSION_PINNED = 'v1.19.27'
 const META_URL_PREFIX = `https://github.com/MetaCubeX/mihomo/releases/download`
 let META_VERSION
 


### PR DESCRIPTION
Latest available Clash.Meta release. One-line pin bump; refresh embedded sidecar via pnpm run prebuild --force.