### PR TITLE
fix(sharelink): robust transport/encoding parsing + partial-import report

### DIFF
--- a/apps/sloth-clash-desktop/app.go
+++ b/apps/sloth-clash-desktop/app.go
@@ -763,11 +763,16 @@ func (a *App) ImportProfileFromText(name string, content string) (AppState, erro
 	}
 	// Validate up front: it must parse as a Clash doc, base64-Clash, or a
 	// supported share-link list. parseClashDocToMap covers all three.
-	if doc, perr := parseClashDocToMap([]byte(content)); perr != nil || len(doc) == 0 {
+	doc, skipped, perr := parseClashDocToMapReport([]byte(content))
+	if perr != nil || len(doc) == 0 {
 		if perr != nil {
 			return a.GetAppState(), fmt.Errorf("not a valid config or supported share link: %w", perr)
 		}
 		return a.GetAppState(), errors.New("not a valid config or supported share link")
+	}
+	importedCount := 0
+	if px, ok := doc["proxies"].([]any); ok {
+		importedCount = len(px)
 	}
 
 	finalName := strings.TrimSpace(name)
@@ -799,6 +804,15 @@ func (a *App) ImportProfileFromText(name string, content string) (AppState, erro
 	a.state.Profile.Profiles = a.profiles
 	if a.state.Profile.ActiveProfileID == "" {
 		a.state.Profile.ActiveProfileID = p.ID
+	}
+	// Surface partial imports instead of silently dropping nodes: a V2Ray list
+	// with unsupported schemes / malformed links keeps the good nodes and tells
+	// the user how many were skipped. (Frontend can render this as a toast.)
+	if len(skipped) > 0 {
+		a.state.Connection.LastWarning = fmt.Sprintf(
+			"Imported %d node(s); skipped %d unsupported or invalid share link(s).",
+			importedCount, len(skipped),
+		)
 	}
 	a.state.UpdatedAt = time.Now().Unix()
 	if err := a.persistProfilesLocked(); err != nil {

--- a/apps/sloth-clash-desktop/sharelink/sharelink.go
+++ b/apps/sloth-clash-desktop/sharelink/sharelink.go
@@ -12,6 +12,7 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"net"
 	"net/url"
 	"strconv"
 	"strings"
@@ -584,12 +585,16 @@ func splitEq(s string) (string, string) {
 }
 
 func splitHostPort(s string) (string, int) {
-	h, p, found := strings.Cut(s, ":")
-	if !found {
-		return s, 0
+	// net.SplitHostPort handles IPv6 literals (`[2001:db8::1]:8388` → host
+	// `2001:db8::1`, port 8388) as well as `host:port`. A naive Cut on the
+	// first ':' would mangle IPv6 servers in legacy/SIP002 ss links.
+	if h, p, err := net.SplitHostPort(s); err == nil {
+		port, _ := strconv.Atoi(p)
+		return h, port
 	}
-	port, _ := strconv.Atoi(p)
-	return h, port
+	// No port present (or unparseable) — strip any brackets and report port 0
+	// so the caller's "missing server/port" guard fires.
+	return strings.Trim(s, "[]"), 0
 }
 
 func splitCSV(s string) []string {

--- a/apps/sloth-clash-desktop/sharelink/sharelink.go
+++ b/apps/sloth-clash-desktop/sharelink/sharelink.go
@@ -150,6 +150,11 @@ func parseVless(link string) (Proxy, error) {
 	if flow := q.Get("flow"); flow != "" {
 		p["flow"] = flow
 	}
+	// packet-encoding (xudp/packetaddr) — our nodes set xudp; without it UDP
+	// over the proxy degrades vs the YAML profile.
+	if pe := q.Get("packetEncoding"); pe != "" {
+		p["packet-encoding"] = pe
+	}
 	security := q.Get("security")
 	if security == "tls" || security == "reality" || q.Get("sni") != "" {
 		p["tls"] = true
@@ -447,6 +452,33 @@ func applyTransport(p Proxy, network string, q url.Values) {
 	case "grpc":
 		if sn := q.Get("serviceName"); sn != "" {
 			p["grpc-opts"] = map[string]any{"grpc-service-name": sn}
+		}
+	case "xhttp":
+		// XHTTP (a.k.a. SplitHTTP) — heavily used by our own nodes. Without
+		// mapping these opts the proxy parses but cannot connect.
+		xo := map[string]any{}
+		if path := q.Get("path"); path != "" {
+			xo["path"] = path
+		}
+		if mode := q.Get("mode"); mode != "" {
+			xo["mode"] = mode
+		}
+		if host := q.Get("host"); host != "" {
+			xo["host"] = host
+		}
+		if len(xo) > 0 {
+			p["xhttp-opts"] = xo
+		}
+	case "h2":
+		h2 := map[string]any{}
+		if path := q.Get("path"); path != "" {
+			h2["path"] = path
+		}
+		if host := q.Get("host"); host != "" {
+			h2["host"] = splitCSV(host) // mihomo h2-opts.host is a list
+		}
+		if len(h2) > 0 {
+			p["h2-opts"] = h2
 		}
 	}
 }

--- a/apps/sloth-clash-desktop/sharelink/sharelink_realworld_test.go
+++ b/apps/sloth-clash-desktop/sharelink/sharelink_realworld_test.go
@@ -90,6 +90,27 @@ func TestRealWorldVlessPacketEncodingXudp(t *testing.T) {
 	wantField(t, p, "packet-encoding", "xudp")
 }
 
+// ss with an IPv6 literal server (SIP002). The naive host:port splitter used
+// to mangle the address; net.SplitHostPort handles the brackets.
+func TestRealWorldSSIPv6SIP002(t *testing.T) {
+	link := "ss://" + b64("aes-256-gcm:secretpass") + "@[2001:db8::1]:8388#v6"
+	p := mustParse(t, link)
+	wantField(t, p, "server", "2001:db8::1")
+	wantField(t, p, "port", 8388)
+	wantField(t, p, "cipher", "aes-256-gcm")
+	wantField(t, p, "password", "secretpass")
+}
+
+// ss password containing ':' must survive (method is the token before the
+// FIRST colon; the rest is the password). Guards against a regression to a
+// last-colon split.
+func TestRealWorldSSPasswordWithColon(t *testing.T) {
+	link := "ss://" + b64("aes-256-gcm:pa:ss:word") + "@h.example.com:8388#c"
+	p := mustParse(t, link)
+	wantField(t, p, "cipher", "aes-256-gcm")
+	wantField(t, p, "password", "pa:ss:word")
+}
+
 // vmess with JSON boolean tls + sni. PASSES because the sni branch sets
 // tls=true — NOT because we handle the bool. The pure bool-without-sni case is
 // a known minor gap (rare: real tls nodes carry sni). Kept to lock in the

--- a/apps/sloth-clash-desktop/sharelink/sharelink_realworld_test.go
+++ b/apps/sloth-clash-desktop/sharelink/sharelink_realworld_test.go
@@ -1,0 +1,102 @@
+package sharelink
+
+// Real-world share-link tests modeled on SlothClash's OWN production nodes
+// (yachiru.xyz: vless + reality + xtls-rprx-vision, xhttp transport, xudp
+// packet-encoding). These encode the CORRECT mihomo output we expect.
+//
+// Tests that currently FAIL are not noise — they are the proven bug list for
+// the share-link parser (see architecture/sharelink-parsing.md fragility
+// findings). They should go green together with the parser fix on the
+// fix/sharelink-parsing branch.
+
+import "testing"
+
+// helper: parse and require no error
+func mustParse(t *testing.T, link string) Proxy {
+	t.Helper()
+	p, err := ParseLink(link)
+	if err != nil {
+		t.Fatalf("ParseLink(%q) error: %v", link, err)
+	}
+	return p
+}
+
+func wantField(t *testing.T, p Proxy, key string, want any) {
+	t.Helper()
+	got, ok := p[key]
+	if !ok {
+		t.Errorf("missing field %q (want %v)", key, want)
+		return
+	}
+	if got != want {
+		t.Errorf("field %q = %v (%T), want %v (%T)", key, got, got, want, want)
+	}
+}
+
+// vless + reality + xtls-rprx-vision over TCP — the "🚀" nodes. Core fields
+// MUST all map. (Expected GREEN with the current parser.)
+func TestRealWorldVlessRealityVisionTCP(t *testing.T) {
+	link := "vless://2dcc5c5a-7ad4-441f-85b8-f2e82bc85dec@r1-ro.yachiru.xyz:443" +
+		"?type=tcp&security=reality&pbk=ky3amiQnMnNmwVY2oCMTvNgn0eISsdtz49hPEta3Ij4" +
+		"&sid=8d7e666a4421c908&flow=xtls-rprx-vision&fp=chrome&sni=r1-ro.yachiru.xyz#RO"
+	p := mustParse(t, link)
+	wantField(t, p, "type", "vless")
+	wantField(t, p, "server", "r1-ro.yachiru.xyz")
+	wantField(t, p, "port", 443)
+	wantField(t, p, "uuid", "2dcc5c5a-7ad4-441f-85b8-f2e82bc85dec")
+	wantField(t, p, "network", "tcp")
+	wantField(t, p, "flow", "xtls-rprx-vision")
+	wantField(t, p, "tls", true)
+	wantField(t, p, "servername", "r1-ro.yachiru.xyz")
+	wantField(t, p, "client-fingerprint", "chrome")
+	ro, ok := p["reality-opts"].(map[string]any)
+	if !ok {
+		t.Fatalf("reality-opts missing/wrong type: %#v", p["reality-opts"])
+	}
+	if ro["public-key"] != "ky3amiQnMnNmwVY2oCMTvNgn0eISsdtz49hPEta3Ij4" {
+		t.Errorf("reality public-key = %v", ro["public-key"])
+	}
+	if ro["short-id"] != "8d7e666a4421c908" {
+		t.Errorf("reality short-id = %v", ro["short-id"])
+	}
+}
+
+// vless + reality over XHTTP — the "🔒" nodes. The transport opts MUST survive.
+// (Expected RED today: applyTransport ignores xhttp → xhttp-opts dropped.)
+func TestRealWorldVlessRealityXHTTP(t *testing.T) {
+	link := "vless://2dcc5c5a-7ad4-441f-85b8-f2e82bc85dec@r2-ro.yachiru.xyz:443" +
+		"?type=xhttp&security=reality&pbk=ky3amiQnMnNmwVY2oCMTvNgn0eISsdtz49hPEta3Ij4" +
+		"&sid=8d7e666a4421c908&fp=chrome&sni=r2-ro.yachiru.xyz&path=%2F&mode=auto#RO-xhttp"
+	p := mustParse(t, link)
+	wantField(t, p, "network", "xhttp")
+	opts, ok := p["xhttp-opts"].(map[string]any)
+	if !ok {
+		t.Fatalf("xhttp-opts missing/wrong type: %#v (xhttp transport silently dropped)", p["xhttp-opts"])
+	}
+	if opts["path"] != "/" {
+		t.Errorf("xhttp-opts.path = %v, want /", opts["path"])
+	}
+	if opts["mode"] != "auto" {
+		t.Errorf("xhttp-opts.mode = %v, want auto", opts["mode"])
+	}
+}
+
+// packet-encoding=xudp must carry through for vless (their nodes set it; UDP
+// degrades without it). (Expected RED today: packetEncoding not parsed.)
+func TestRealWorldVlessPacketEncodingXudp(t *testing.T) {
+	link := "vless://uuid-x@r1-nl.yachiru.xyz:443?type=tcp&security=reality" +
+		"&pbk=PBK&sid=SID&flow=xtls-rprx-vision&sni=r1-nl.yachiru.xyz&packetEncoding=xudp#NL"
+	p := mustParse(t, link)
+	wantField(t, p, "packet-encoding", "xudp")
+}
+
+// vmess with JSON boolean tls + sni. PASSES because the sni branch sets
+// tls=true — NOT because we handle the bool. The pure bool-without-sni case is
+// a known minor gap (rare: real tls nodes carry sni). Kept to lock in the
+// realistic case; see architecture/sharelink-parsing.md.
+func TestRealWorldVmessTLSBoolean(t *testing.T) {
+	// {"v":"2","ps":"vm","add":"vm.example.com","port":"443","id":"u","aid":"0","net":"ws","tls":true,"sni":"vm.example.com","path":"/p"}
+	link := "vmess://eyJ2IjoiMiIsInBzIjoidm0iLCJhZGQiOiJ2bS5leGFtcGxlLmNvbSIsInBvcnQiOiI0NDMiLCJpZCI6InUiLCJhaWQiOiIwIiwibmV0Ijoid3MiLCJ0bHMiOnRydWUsInNuaSI6InZtLmV4YW1wbGUuY29tIiwicGF0aCI6Ii9wIn0="
+	p := mustParse(t, link)
+	wantField(t, p, "tls", true)
+}

--- a/apps/sloth-clash-desktop/subscription_import_report_test.go
+++ b/apps/sloth-clash-desktop/subscription_import_report_test.go
@@ -1,0 +1,38 @@
+package main
+
+import "testing"
+
+// parseClashDocToMapReport must keep the good nodes AND report the share-link
+// lines it could not convert, so import paths can say "imported N, skipped M"
+// instead of silently dropping nodes (the original bug: skipped was discarded).
+func TestParseClashDocReportsSkippedShareLinks(t *testing.T) {
+	text := "vless://11111111-2222-3333-4444-555555555555@a.example.com:443?type=tcp#ok\n" +
+		"garbage://nope\n" +
+		"ss://bad\n"
+	doc, skipped, err := parseClashDocToMapReport([]byte(text))
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	px, _ := doc["proxies"].([]any)
+	if len(px) != 1 {
+		t.Fatalf("imported proxies = %d, want 1", len(px))
+	}
+	if len(skipped) != 2 {
+		t.Fatalf("skipped = %d (%v), want 2", len(skipped), skipped)
+	}
+}
+
+// A clean Clash-YAML doc reports no skipped lines (skipped is share-link-only).
+func TestParseClashDocCleanYAMLReportsNoSkipped(t *testing.T) {
+	yaml := "proxies:\n  - {name: a, type: ss, server: s.example.com, port: 443, cipher: aes-128-gcm, password: pw}\n"
+	doc, skipped, err := parseClashDocToMapReport([]byte(yaml))
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if doc == nil {
+		t.Fatal("doc is nil")
+	}
+	if len(skipped) != 0 {
+		t.Fatalf("skipped = %v, want none for clean YAML", skipped)
+	}
+}

--- a/apps/sloth-clash-desktop/subscription_yaml.go
+++ b/apps/sloth-clash-desktop/subscription_yaml.go
@@ -231,35 +231,45 @@ func marshalRuntimeYAML(v any) ([]byte, error) {
 }
 
 func parseClashDocToMap(b []byte) (map[string]any, error) {
+	m, _, err := parseClashDocToMapReport(b)
+	return m, err
+}
+
+// parseClashDocToMapReport is parseClashDocToMap plus the list of share-link
+// lines it could NOT convert (unsupported scheme / malformed). Import paths use
+// it to report "imported N, skipped M" instead of silently dropping nodes. The
+// skipped list is only populated on the share-link branch; Clash-YAML / base64
+// inputs return nil (no per-line concept).
+func parseClashDocToMapReport(b []byte) (map[string]any, []string, error) {
 	b = bytes.TrimSpace(b)
 	if len(b) == 0 {
-		return nil, errors.New("empty subscription body")
+		return nil, nil, errors.New("empty subscription body")
 	}
 	b = bytes.TrimPrefix(b, []byte{0xEF, 0xBB, 0xBF})
 
 	var m map[string]any
 	err := yaml.Unmarshal(b, &m)
 	if err == nil && len(m) > 0 {
-		return m, nil
+		return m, nil, nil
 	}
 	if dec, derr := decodeBase64Flexible(strings.TrimSpace(string(b))); derr == nil && len(dec) > 0 {
 		dec = bytes.TrimSpace(dec)
 		dec = bytes.TrimPrefix(dec, []byte{0xEF, 0xBB, 0xBF})
 		var m2 map[string]any
 		if err2 := yaml.Unmarshal(dec, &m2); err2 == nil && len(m2) > 0 {
-			return m2, nil
+			return m2, nil, nil
 		}
 	}
 	// Not Clash YAML (plain or base64). Try a V2Ray-style share-link list
 	// (vless://, vmess://, ss://, trojan://, hysteria2://, tuic://) — single
 	// link, newline list, or base64 envelope — and synthesize a runnable config.
-	if doc, ok := shareLinksToClashMap(string(b)); ok {
-		return doc, nil
+	if doc, skipped, ok := shareLinksToClashMap(string(b)); ok {
+		return doc, skipped, nil
 	}
 	if err != nil {
-		return nil, err
+		return nil, nil, err
 	}
-	return nil, errors.New("invalid clash yaml mapping")
+	return nil, nil, errors.New("invalid clash yaml mapping")
 }
 
 // shareLinksToClashMap converts proxy share links into a minimal but complete
@@ -267,15 +277,15 @@ func parseClashDocToMap(b []byte) (map[string]any, error) {
 // (all nodes + DIRECT), and a catch-all rule. Returns ok=false if no supported
 // link is found. Having proxy-groups + rules makes the result a "full profile"
 // so the normal merge pipeline handles ports/TUN/overlay uniformly.
-func shareLinksToClashMap(text string) (map[string]any, bool) {
-	proxies, _ := sharelink.ParseMany(text)
+func shareLinksToClashMap(text string) (map[string]any, []string, bool) {
+	proxies, skipped := sharelink.ParseMany(text)
 	if len(proxies) == 0 {
 		if dec := sharelink.DecodeBase64Block(text); dec != "" {
-			proxies, _ = sharelink.ParseMany(dec)
+			proxies, skipped = sharelink.ParseMany(dec)
 		}
 	}
 	if len(proxies) == 0 {
-		return nil, false
+		return nil, skipped, false
 	}
 	rawProxies := make([]any, 0, len(proxies))
 	groupProxies := make([]any, 0, len(proxies)+1)
@@ -290,7 +300,7 @@ func shareLinksToClashMap(text string) (map[string]any, bool) {
 			map[string]any{"name": "PROXY", "type": "select", "proxies": groupProxies},
 		},
 		"rules": []any{"MATCH,PROXY"},
-	}, true
+	}, skipped, true
 }
 
 // subscriptionDocIsFullProfile reports whether the downloaded document should be used as the


### PR DESCRIPTION
Real-node tests proved share-link import silently dropped fields/nodes. Map xhttp/h2 + packet-encoding (vless), handle IPv6 ss via net.SplitHostPort, and surface skipped/unsupported links (Imported N / skipped M) instead of dropping silently. Adds real-world + import-report tests; full module green.
