### PR TITLE
fix(profile): let local/no-URL profiles connect and edit

### DIFF
--- a/apps/sloth-clash-desktop/core_manager.go
+++ b/apps/sloth-clash-desktop/core_manager.go
@@ -1070,7 +1070,7 @@ func (a *App) forceRestartCoreForProfile(profile Profile, gen uint64, enableTun 
 // to be connected) so the core boots in the final state without a follow-up
 // PATCH flip — exactly how clash-verge-rev's start_core works.
 func (a *App) startEmbeddedCore(profile Profile, gen uint64, enableTun bool) error {
-	if strings.TrimSpace(profile.URL) == "" {
+	if strings.TrimSpace(profile.URL) == "" && !profileHasLocalConfig(profile) {
 		return errors.New("active profile has no subscription URL")
 	}
 

--- a/apps/sloth-clash-desktop/local_config_test.go
+++ b/apps/sloth-clash-desktop/local_config_test.go
@@ -1,0 +1,66 @@
+package main
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"gopkg.in/yaml.v3"
+)
+
+func TestProfileHasLocalConfig(t *testing.T) {
+	cases := []struct {
+		name string
+		p    Profile
+		want bool
+	}{
+		{"local type", Profile{Type: "local"}, true},
+		{"local type cased", Profile{Type: "Local"}, true},
+		{"skip auto config", Profile{SkipAutoConfig: true}, true},
+		{"url profile", Profile{URL: "https://example.com/sub"}, false},
+		{"empty profile", Profile{}, false},
+	}
+	for _, c := range cases {
+		if got := profileHasLocalConfig(c.p); got != c.want {
+			t.Errorf("%s: profileHasLocalConfig = %v, want %v", c.name, got, c.want)
+		}
+	}
+}
+
+// The core of the local-config bug fix: a local profile (body cache seeded at
+// import, NO subscription URL) must produce a valid runtime config.yaml through
+// the normal cache-first pipeline. If this passes, relaxing the URL guards is
+// sufficient — Connect will build a working config without a URL.
+func TestLocalProfileBuildsRuntimeConfigFromSeededCacheWithoutURL(t *testing.T) {
+	dataDir := t.TempDir()
+	// A local profile seeds its body cache at import (ImportProfileFromText).
+	// Use a Clash-YAML body (shawn020308's case: local yaml file, no URL).
+	body := "" +
+		"proxies:\n" +
+		"  - {name: n1, type: ss, server: s.example.com, port: 443, cipher: aes-128-gcm, password: pw}\n" +
+		"proxy-groups:\n" +
+		"  - {name: PROXY, type: select, proxies: [n1, DIRECT]}\n" +
+		"rules:\n" +
+		"  - MATCH,PROXY\n"
+	writeSubscriptionBodyCache(dataDir, []byte(body))
+
+	// subURL = "" — exactly what a local profile passes. Cache-first means no network.
+	outcome, err := tryWriteMergedFullProfile(dataDir, "", "", "", "", 0, 7890, "secret", "tun", false, true)
+	if err != nil {
+		t.Fatalf("pipeline error: %v", err)
+	}
+	if outcome != pipelineOK {
+		t.Fatalf("outcome = %v, want pipelineOK", outcome)
+	}
+	b, err := os.ReadFile(filepath.Join(dataDir, "config.yaml"))
+	if err != nil {
+		t.Fatalf("config.yaml not written: %v", err)
+	}
+	var m map[string]any
+	if err := yaml.Unmarshal(b, &m); err != nil {
+		t.Fatalf("generated config.yaml is invalid yaml: %v", err)
+	}
+	if px, ok := m["proxies"].([]any); !ok || len(px) == 0 {
+		t.Fatalf("expected proxies in generated config, got: %v", m["proxies"])
+	}
+}

--- a/apps/sloth-clash-desktop/profile_config_api.go
+++ b/apps/sloth-clash-desktop/profile_config_api.go
@@ -58,13 +58,9 @@ func (a *App) GetProfileRulesBaseline(profileID string) ProfileRulesBaseline {
 	if !found {
 		return ProfileRulesBaseline{LastError: "profile not found"}
 	}
-	if strings.TrimSpace(target.URL) == "" {
-		return ProfileRulesBaseline{LastError: "profile has no subscription url"}
-	}
-
 	ctx, cancel := context.WithTimeout(context.Background(), 45*time.Second)
 	defer cancel()
-	body, err := fetchSubscriptionBody(ctx, target.URL)
+	body, err := a.loadProfileSubscriptionBody(ctx, target)
 	if err != nil {
 		return ProfileRulesBaseline{LastError: err.Error()}
 	}
@@ -137,13 +133,9 @@ func (a *App) GetProfileProxyGroupsBaseline(profileID string) ProfileProxyGroups
 	if !found {
 		return ProfileProxyGroupsBaseline{LastError: "profile not found"}
 	}
-	if strings.TrimSpace(target.URL) == "" {
-		return ProfileProxyGroupsBaseline{LastError: "profile has no subscription url"}
-	}
-
 	ctx, cancel := context.WithTimeout(context.Background(), 45*time.Second)
 	defer cancel()
-	body, err := fetchSubscriptionBody(ctx, target.URL)
+	body, err := a.loadProfileSubscriptionBody(ctx, target)
 	if err != nil {
 		return ProfileProxyGroupsBaseline{LastError: err.Error()}
 	}
@@ -238,7 +230,7 @@ func (a *App) ensureProfileConfigSnapshot(profileID string) error {
 	if !found {
 		return errors.New("profile not found")
 	}
-	if strings.TrimSpace(target.URL) == "" {
+	if strings.TrimSpace(target.URL) == "" && !profileHasLocalConfig(target) {
 		return errors.New("profile has no subscription url")
 	}
 	if traffic != "proxy" && traffic != "tun" {
@@ -403,7 +395,7 @@ func (a *App) reloadActiveProfileConfig() error {
 	if !found {
 		return nil
 	}
-	if strings.TrimSpace(target.URL) == "" {
+	if strings.TrimSpace(target.URL) == "" && !profileHasLocalConfig(target) {
 		return errors.New("profile has no subscription url")
 	}
 
@@ -428,6 +420,39 @@ func (a *App) reloadActiveProfileConfig() error {
 //     and merges it without restarting. Because the YAML reflects the caller's
 //     intent verbatim, tun.enable is stable across reloads that preserve the
 //     intent, so there is no PATCH-driven wintun flap.
+// profileHasLocalConfig reports whether a profile supplies its own config
+// WITHOUT a subscription URL: a local/imported profile (Type "local" — its body
+// is seeded into the subscription body cache at import, see ImportProfileFromText)
+// or one with a hand-edited on-disk config.yaml (SkipAutoConfig). Such profiles
+// must NOT be rejected by the "needs a subscription URL" guards — the runtime
+// pipeline (tryWriteMergedFullProfile → cache-first) builds their config from the
+// cached body / on-disk file, no network involved. (See architecture/core-lifecycle.md #1.)
+func profileHasLocalConfig(p Profile) bool {
+	return strings.EqualFold(strings.TrimSpace(p.Type), "local") || p.SkipAutoConfig
+}
+
+// loadProfileSubscriptionBody returns the subscription body used to build the
+// read-only baseline views (rules / proxy-groups editors): the seeded on-disk
+// body cache for local profiles (Type "local", no URL), or a fresh network
+// fetch for URL-backed profiles. Keeps local profiles first-class in the editors.
+func (a *App) loadProfileSubscriptionBody(ctx context.Context, p Profile) ([]byte, error) {
+	if strings.TrimSpace(p.URL) == "" {
+		if !profileHasLocalConfig(p) {
+			return nil, errors.New("profile has no subscription url")
+		}
+		root, err := slothDataRoot()
+		if err != nil {
+			return nil, err
+		}
+		body := readSubscriptionBodyCache(filepath.Join(root, "runtime", p.ID))
+		if len(body) == 0 {
+			return nil, errors.New("local profile has no cached config body")
+		}
+		return body, nil
+	}
+	return fetchSubscriptionBody(ctx, p.URL)
+}
+
 func (a *App) applyRuntimeConfig(profile Profile, traffic string, enableTun bool) error {
 	return a.applyRuntimeConfigWithGen(profile, traffic, enableTun, 0)
 }
@@ -450,7 +475,7 @@ func (a *App) applyRuntimeConfigWithGen(profile Profile, traffic string, enableT
 		_ = applyStart
 		_ = traceFields
 	}()
-	if strings.TrimSpace(profile.URL) == "" {
+	if strings.TrimSpace(profile.URL) == "" && !profileHasLocalConfig(profile) {
 		return errors.New("profile has no subscription url")
 	}
 	if traffic != "proxy" && traffic != "tun" {


### PR DESCRIPTION
Local and SkipAutoConfig profiles supply their config from the seeded body cache or on-disk config.yaml, but four guards rejected them with a no-subscription-URL error before the cache-first pipeline ran, so a local YAML or share-link profile could never connect. Relax those guards via profileHasLocalConfig(), and make the rules and proxy-groups baseline editors read the cached body for local profiles. Cache refresh is empty-URL-safe. Adds tests proving a URL-less local profile builds a valid runtime config.