### PR TITLE
feat(i18n): localize profile/settings modals and context menu

### DIFF
--- a/apps/sloth-clash-desktop/frontend/src/components/DeleteProfileModal.tsx
+++ b/apps/sloth-clash-desktop/frontend/src/components/DeleteProfileModal.tsx
@@ -1,3 +1,5 @@
+import { useTranslation } from 'react-i18next'
+
 export type DeleteProfileTarget = { id: string; name: string }
 
 export function DeleteProfileModal({
@@ -9,6 +11,7 @@ export function DeleteProfileModal({
   onClose: () => void
   onConfirm: (id: string) => void
 }) {
+  const { t } = useTranslation()
   if (!target) return null
   return (
     <div
@@ -25,23 +28,24 @@ export function DeleteProfileModal({
         onClick={(e) => e.stopPropagation()}
       >
         <h3 id="deleteProfileTitle" className="modalTitle">
-          Delete profile
+          {t('ui.profiles.deleteModal.title')}
         </h3>
         <p className="muted small">
-          Remove <strong>{target.name}</strong> from this device? This does not
-          cancel a remote subscription.
+          {t('ui.profiles.deleteModal.bodyPrefix')}{' '}
+          <strong>{target.name}</strong>{' '}
+          {t('ui.profiles.deleteModal.bodySuffix')}
         </p>
         <div className="modalFooter">
           <div className="modalFooterRight" style={{ width: '100%' }}>
             <button type="button" className="btn ghost" onClick={onClose}>
-              Cancel
+              {t('common.cancel')}
             </button>
             <button
               type="button"
               className="btn primary"
               onClick={() => onConfirm(target.id)}
             >
-              Delete
+              {t('common.delete')}
             </button>
           </div>
         </div>

--- a/apps/sloth-clash-desktop/frontend/src/components/ImportProfileModal.tsx
+++ b/apps/sloth-clash-desktop/frontend/src/components/ImportProfileModal.tsx
@@ -1,4 +1,5 @@
 import { useRef } from 'react'
+import { useTranslation } from 'react-i18next'
 
 export type ImportMode = 'url' | 'paste'
 
@@ -25,26 +26,41 @@ function tryBase64(s: string): string {
 
 type Detection = { kind: 'yaml' | 'links' | 'unknown'; label: string }
 
-function detect(raw: string): Detection | null {
-  const t = raw.trim()
-  if (!t) return null
-  if (looksLikeYaml(t)) return { kind: 'yaml', label: 'Clash YAML config' }
-  const n = countLinks(t)
+type TranslateFn = (key: string, options?: Record<string, unknown>) => string
+
+function detect(raw: string, t: TranslateFn): Detection | null {
+  const trimmed = raw.trim()
+  if (!trimmed) return null
+  if (looksLikeYaml(trimmed))
+    return { kind: 'yaml', label: t('ui.profiles.importModal.detectYaml') }
+  const n = countLinks(trimmed)
   if (n > 0)
-    return { kind: 'links', label: `${n} share link${n > 1 ? 's' : ''}` }
-  const dec = tryBase64(t)
+    return {
+      kind: 'links',
+      label: t(
+        n > 1
+          ? 'ui.profiles.importModal.detectLinksPlural'
+          : 'ui.profiles.importModal.detectLinksSingular',
+        { count: n },
+      ),
+    }
+  const dec = tryBase64(trimmed)
   if (dec) {
     const m = countLinks(dec)
     if (m > 0)
       return {
         kind: 'links',
-        label: `${m} share link${m > 1 ? 's' : ''} (base64)`,
+        label: t(
+          m > 1
+            ? 'ui.profiles.importModal.detectLinksBase64Plural'
+            : 'ui.profiles.importModal.detectLinksBase64Singular',
+          { count: m },
+        ),
       }
   }
   return {
     kind: 'unknown',
-    label:
-      'Unrecognized — expecting Clash YAML or vless:// / vmess:// / ss:// / trojan:// links',
+    label: t('ui.profiles.importModal.detectUnknown'),
   }
 }
 
@@ -81,10 +97,11 @@ export function ImportProfileModal({
   onClose: () => void
   onSubmit: () => void
 }) {
+  const { t } = useTranslation()
   const fileRef = useRef<HTMLInputElement>(null)
   if (!open) return null
 
-  const detection = mode === 'paste' ? detect(content) : null
+  const detection = mode === 'paste' ? detect(content, t) : null
   const canSubmit =
     !busy &&
     (mode === 'url'
@@ -119,7 +136,7 @@ export function ImportProfileModal({
             className={mode === 'url' ? 'btn' : 'btn ghost'}
             onClick={() => onModeChange('url')}
           >
-            Subscription URL
+            {t('ui.profiles.importModal.tabUrl')}
           </button>
           <button
             type="button"
@@ -128,13 +145,15 @@ export function ImportProfileModal({
             className={mode === 'paste' ? 'btn' : 'btn ghost'}
             onClick={() => onModeChange('paste')}
           >
-            Paste / File
+            {t('ui.profiles.importModal.tabPaste')}
           </button>
         </div>
 
         {mode === 'url' ? (
           <label className="field modalField">
-            <span className="fieldLab">Subscription URL</span>
+            <span className="fieldLab">
+              {t('ui.profiles.importModal.subscriptionUrl')}
+            </span>
             <input
               className="input"
               value={url}
@@ -145,7 +164,7 @@ export function ImportProfileModal({
         ) : (
           <label className="field modalField">
             <span className="fieldLab">
-              Config or share links
+              {t('ui.profiles.importModal.configOrLinks')}
               {detection ? (
                 <span className={`importDetect importDetect-${detection.kind}`}>
                   {' '}
@@ -159,16 +178,15 @@ export function ImportProfileModal({
               rows={10}
               spellCheck={false}
               onChange={(e) => onContentChange(e.target.value)}
-              placeholder={
-                'Paste a mihomo/Clash config.yaml,\nor share links — one per line:\nvless://…\nvmess://…\ntrojan://…'
-              }
+              placeholder={t('ui.profiles.importModal.pastePlaceholder')}
             />
           </label>
         )}
 
         <label className="field modalField">
           <span className="fieldLab">
-            Display name <span className="optional">(optional)</span>
+            {t('ui.profiles.importModal.displayName')}{' '}
+            <span className="optional">{t('common.optional')}</span>
           </span>
           <input
             className="input"
@@ -176,8 +194,8 @@ export function ImportProfileModal({
             onChange={(e) => onNameChange(e.target.value)}
             placeholder={
               mode === 'url'
-                ? 'Empty = use Profile-Title from server'
-                : 'Empty = "Local config"'
+                ? t('ui.profiles.importModal.namePlaceholderUrl')
+                : t('ui.profiles.importModal.namePlaceholderPaste')
             }
           />
         </label>
@@ -189,7 +207,7 @@ export function ImportProfileModal({
               className="btn btnModalSecondary"
               onClick={onPasteFromClipboard}
             >
-              Paste from clipboard
+              {t('ui.profiles.importModal.pasteFromClipboard')}
             </button>
             {mode === 'paste' ? (
               <>
@@ -198,7 +216,7 @@ export function ImportProfileModal({
                   className="btn btnModalSecondary"
                   onClick={() => fileRef.current?.click()}
                 >
-                  Load from file…
+                  {t('ui.profiles.importModal.loadFromFile')}
                 </button>
                 <input
                   ref={fileRef}
@@ -220,7 +238,7 @@ export function ImportProfileModal({
               disabled={busy}
               onClick={onClose}
             >
-              Cancel
+              {t('common.cancel')}
             </button>
             <button
               type="button"
@@ -228,7 +246,7 @@ export function ImportProfileModal({
               disabled={!canSubmit}
               onClick={onSubmit}
             >
-              Import
+              {t('common.import')}
             </button>
           </div>
         </div>

--- a/apps/sloth-clash-desktop/frontend/src/components/ProfileContextMenu.tsx
+++ b/apps/sloth-clash-desktop/frontend/src/components/ProfileContextMenu.tsx
@@ -1,4 +1,5 @@
 import { useLayoutEffect, useRef, useState } from 'react'
+import { useTranslation } from 'react-i18next'
 
 export type ProfileMenuTarget = {
   id: string
@@ -32,6 +33,7 @@ export function ProfileContextMenu({
   onOpenProxyGroups: (id: string, name: string) => void
   onOpenEditFile: (id: string, name: string) => void
 }) {
+  const { t } = useTranslation()
   // Hooks must run unconditionally — declare them before the early return.
   const menuRef = useRef<HTMLDivElement | null>(null)
   // Position is initialised to the click coordinates and then clamped against
@@ -96,7 +98,7 @@ export function ProfileContextMenu({
         disabled={!hasUrl}
         onClick={() => onUpdate(target.id)}
       >
-        Update profile now
+        {t('ui.profiles.contextMenu.updateNow')}
       </button>
       <button
         type="button"
@@ -105,7 +107,7 @@ export function ProfileContextMenu({
           onEditInfo(target.id, target.name, String(profile?.url ?? ''))
         }
       >
-        Edit info
+        {t('ui.profiles.contextMenu.editInfo')}
       </button>
       <button
         type="button"
@@ -113,43 +115,43 @@ export function ProfileContextMenu({
         disabled={!hasUrl}
         onClick={() => onCopyUrl(String(profile?.url ?? ''))}
       >
-        Copy subscription URL
+        {t('ui.profiles.contextMenu.copySubscriptionUrl')}
       </button>
       <button
         type="button"
         className="ctxItem"
         onClick={() => onOpenRules(target.id, target.name)}
       >
-        Rules
+        {t('ui.profiles.contextMenu.rules')}
       </button>
       <button
         type="button"
         className="ctxItem"
         onClick={() => onDelete(target.id, target.name)}
       >
-        Delete profile
+        {t('ui.profiles.contextMenu.deleteProfile')}
       </button>
-      <div className="ctxSection">Advanced</div>
+      <div className="ctxSection">{t('ui.profiles.contextMenu.advanced')}</div>
       <button
         type="button"
         className="ctxItem ctxItemSub"
         onClick={() => onOpenExtendConfig(target.id, target.name)}
       >
-        Extend config
+        {t('ui.profiles.contextMenu.extendConfig')}
       </button>
       <button
         type="button"
         className="ctxItem ctxItemSub"
         onClick={() => onOpenProxyGroups(target.id, target.name)}
       >
-        Proxy groups
+        {t('ui.profiles.contextMenu.proxyGroups')}
       </button>
       <button
         type="button"
         className="ctxItem ctxItemSub"
         onClick={() => onOpenEditFile(target.id, target.name)}
       >
-        Edit file
+        {t('ui.profiles.contextMenu.editFile')}
       </button>
     </div>
   )

--- a/apps/sloth-clash-desktop/frontend/src/components/ProfileEditInfoModal.tsx
+++ b/apps/sloth-clash-desktop/frontend/src/components/ProfileEditInfoModal.tsx
@@ -1,3 +1,5 @@
+import { useTranslation } from 'react-i18next'
+
 export type ProfileEditInfoTarget = { id: string; name: string; url: string }
 
 export function ProfileEditInfoModal({
@@ -29,6 +31,7 @@ export function ProfileEditInfoModal({
   onClose: () => void
   onSave: (id: string) => void
 }) {
+  const { t } = useTranslation()
   if (!target) return null
   return (
     <div
@@ -45,14 +48,11 @@ export function ProfileEditInfoModal({
         onClick={(e) => e.stopPropagation()}
       >
         <h3 id="editInfoTitle" className="modalTitle">
-          Edit profile info
+          {t('ui.profiles.editInfo.title')}
         </h3>
-        <p className="muted small">
-          Display name and subscription link. Leave the URL field empty to keep
-          the current link unchanged.
-        </p>
+        <p className="muted small">{t('ui.profiles.editInfo.blurb')}</p>
         <label className="field modalField">
-          <span className="fieldLab">Name</span>
+          <span className="fieldLab">{t('ui.profiles.editInfo.name')}</span>
           <input
             className="input"
             value={name}
@@ -61,27 +61,33 @@ export function ProfileEditInfoModal({
           />
         </label>
         <label className="field modalField">
-          <span className="fieldLab">Subscription URL</span>
+          <span className="fieldLab">
+            {t('ui.profiles.editInfo.subscriptionUrl')}
+          </span>
           <input
             className="input"
             value={url}
             onChange={(e) => onUrlChange(e.target.value)}
-            placeholder="Leave empty to keep current"
+            placeholder={t('ui.profiles.editInfo.urlPlaceholder')}
           />
         </label>
         <div className="fieldGrid">
           <label className="field modalField">
-            <span className="fieldLab">Auto-update</span>
+            <span className="fieldLab">
+              {t('ui.profiles.editInfo.autoUpdate')}
+            </span>
             <button
               type="button"
               className={`trafficKnob ${autoEnabled ? 'on' : ''}`}
               onClick={onAutoEnabledToggle}
             >
-              {autoEnabled ? 'On' : 'Off'}
+              {autoEnabled ? t('common.on') : t('common.off')}
             </button>
           </label>
           <label className="field modalField">
-            <span className="fieldLab">Interval (minutes)</span>
+            <span className="fieldLab">
+              {t('ui.profiles.editInfo.intervalMinutes')}
+            </span>
             <input
               className="input"
               value={autoInterval}
@@ -97,7 +103,7 @@ export function ProfileEditInfoModal({
             disabled={!url.trim()}
             onClick={() => onCopyUrl(url.trim())}
           >
-            Copy URL
+            {t('ui.profiles.editInfo.copyUrl')}
           </button>
           <button
             type="button"
@@ -105,13 +111,13 @@ export function ProfileEditInfoModal({
             disabled={!name.trim()}
             onClick={() => onCopyName(name.trim())}
           >
-            Copy name
+            {t('ui.profiles.editInfo.copyName')}
           </button>
         </div>
         <div className="modalFooter">
           <div className="modalFooterRight" style={{ width: '100%' }}>
             <button type="button" className="btn ghost" onClick={onClose}>
-              Cancel
+              {t('common.cancel')}
             </button>
             <button
               type="button"
@@ -119,7 +125,7 @@ export function ProfileEditInfoModal({
               disabled={!name.trim()}
               onClick={() => onSave(target.id)}
             >
-              Save
+              {t('common.save')}
             </button>
           </div>
         </div>

--- a/apps/sloth-clash-desktop/frontend/src/components/ProfileFileModal.tsx
+++ b/apps/sloth-clash-desktop/frontend/src/components/ProfileFileModal.tsx
@@ -1,3 +1,5 @@
+import { useTranslation } from 'react-i18next'
+
 import { MonacoYamlEditor } from '../MonacoYamlEditor'
 
 import type { ProfileModalTarget } from './ProfileMergeModal'
@@ -23,6 +25,7 @@ export function ProfileFileModal({
   onClose: () => void
   onSave: (id: string) => void
 }) {
+  const { t } = useTranslation()
   if (!target) return null
   return (
     <div
@@ -40,19 +43,21 @@ export function ProfileFileModal({
       >
         <div className="vergeModalHead">
           <h3 id="editFileTitle" className="modalTitle vergeModalTitle">
-            Edit configuration file
+            {t('ui.profiles.fileModal.title')}
           </h3>
         </div>
         <p className="muted small mono tight">{path}</p>
         {loadError ? (
           <p className="muted small tight">
-            Read: {loadError} — you can still paste YAML and save to create the
-            file.
+            {t('ui.profiles.fileModal.readErrorLead', { error: loadError })}
           </p>
         ) : null}
         <label className="field modalField">
           <span className="fieldLab">
-            {target.name} <span className="optional">· loaded config.yaml</span>
+            {target.name}{' '}
+            <span className="optional">
+              {t('ui.profiles.fileModal.loadedConfig')}
+            </span>
           </span>
           <MonacoYamlEditor
             className="modalMonacoWrap"
@@ -62,7 +67,7 @@ export function ProfileFileModal({
           />
           {yamlError ? (
             <span className="muted small" style={{ color: '#ff6b6b' }}>
-              YAML error: {yamlError}
+              {t('common.yamlError', { error: yamlError })}
             </span>
           ) : null}
         </label>
@@ -73,11 +78,11 @@ export function ProfileFileModal({
             disabled={!path}
             onClick={() => onCopyPath(path)}
           >
-            Copy path
+            {t('ui.profiles.fileModal.copyPath')}
           </button>
           <div className="modalFooterRight">
             <button type="button" className="btn ghost" onClick={onClose}>
-              Cancel
+              {t('common.cancel')}
             </button>
             <button
               type="button"
@@ -85,7 +90,7 @@ export function ProfileFileModal({
               disabled={Boolean(yamlError)}
               onClick={() => onSave(target.id)}
             >
-              Save
+              {t('common.save')}
             </button>
           </div>
         </div>

--- a/apps/sloth-clash-desktop/frontend/src/components/ProfileMergeModal.tsx
+++ b/apps/sloth-clash-desktop/frontend/src/components/ProfileMergeModal.tsx
@@ -1,3 +1,5 @@
+import { useTranslation } from 'react-i18next'
+
 import { MonacoYamlEditor } from '../MonacoYamlEditor'
 
 export type ProfileModalTarget = { id: string; name: string }
@@ -19,6 +21,7 @@ export function ProfileMergeModal({
   onClose: () => void
   onSave: (id: string) => void
 }) {
+  const { t } = useTranslation()
   if (!target) return null
   return (
     <div
@@ -36,20 +39,23 @@ export function ProfileMergeModal({
       >
         <div className="vergeModalHead">
           <h3 id="mergeTplTitle" className="modalTitle vergeModalTitle">
-            Profile merge template
+            {t('ui.profiles.mergeModal.title')}
           </h3>
         </div>
         <p className="muted small yamlModalBlurb">
-          Top-level keys merge into the fetched profile;{' '}
+          {t('ui.profiles.mergeModal.blurbLead')}{' '}
           <code className="code">prepend</code> /{' '}
           <code className="code">append</code> /{' '}
-          <code className="code">delete</code> for rules, proxy-groups, and
-          provider maps. Applied whenever Sloth writes{' '}
+          <code className="code">delete</code>{' '}
+          {t('ui.profiles.mergeModal.blurbTail')}{' '}
           <code className="code">config.yaml</code>.
         </p>
         <label className="field modalField">
           <span className="fieldLab">
-            {target.name} <span className="optional">· merge YAML</span>
+            {target.name}{' '}
+            <span className="optional">
+              {t('ui.profiles.mergeModal.mergeYaml')}
+            </span>
           </span>
           <MonacoYamlEditor
             className="modalMonacoWrap"
@@ -59,7 +65,7 @@ export function ProfileMergeModal({
           />
           {yamlError ? (
             <span className="muted small" style={{ color: '#ff6b6b' }}>
-              YAML error: {yamlError}
+              {t('common.yamlError', { error: yamlError })}
             </span>
           ) : null}
         </label>
@@ -69,11 +75,11 @@ export function ProfileMergeModal({
             className="btn btnModalSecondary"
             onClick={onResetScaffold}
           >
-            Reset scaffold
+            {t('ui.profiles.mergeModal.resetScaffold')}
           </button>
           <div className="modalFooterRight">
             <button type="button" className="btn ghost" onClick={onClose}>
-              Cancel
+              {t('common.cancel')}
             </button>
             <button
               type="button"
@@ -81,7 +87,7 @@ export function ProfileMergeModal({
               disabled={Boolean(yamlError)}
               onClick={() => onSave(target.id)}
             >
-              Save
+              {t('common.save')}
             </button>
           </div>
         </div>

--- a/apps/sloth-clash-desktop/frontend/src/components/ProfileProxyModal.tsx
+++ b/apps/sloth-clash-desktop/frontend/src/components/ProfileProxyModal.tsx
@@ -1,4 +1,5 @@
 import { useEffect, useMemo, useState } from 'react'
+import { useTranslation } from 'react-i18next'
 
 import {
   GetProfileProxyGroupsBaseline,
@@ -34,6 +35,7 @@ export function ProfileProxyModal({
   onSaved: (banner: string) => void
   onError: (msg: string) => void
 }) {
+  const { t } = useTranslation()
   // Drafts are derived from the active target on first mount.
   // App.tsx passes `key={target?.id}` so a new target triggers a remount and
   // these lazy initializers run again — no setState-in-effect chain needed.
@@ -180,7 +182,7 @@ export function ProfileProxyModal({
 
   const onSwitchToVisual = () => {
     if (advancedYamlErr) {
-      onError('Fix proxy advanced YAML before switching to Visual mode.')
+      onError(t('ui.profiles.proxyModal.fixYamlBeforeVisual'))
       return
     }
     setUiMode('visual')
@@ -206,7 +208,7 @@ export function ProfileProxyModal({
     if (body == null) return
     try {
       await SetProfileProxyTemplate(target.id, body)
-      onSaved('Proxy groups saved into merge template.')
+      onSaved(t('ui.profiles.proxyModal.savedBanner'))
     } catch (e: any) {
       onError(String(e))
     }
@@ -230,7 +232,7 @@ export function ProfileProxyModal({
       >
         <div className="vergeModalHead">
           <h3 id="pgTitle" className="modalTitle vergeModalTitle">
-            Edit proxy groups
+            {t('ui.profiles.proxyModal.title')}
           </h3>
           <div className="vergeToggleRow">
             <button
@@ -238,14 +240,14 @@ export function ProfileProxyModal({
               className={`btn vergeToggle ${uiMode === 'visual' ? 'primary' : 'ghost'}`}
               onClick={onSwitchToVisual}
             >
-              Visual
+              {t('common.visual')}
             </button>
             <button
               type="button"
               className={`btn vergeToggle ${uiMode === 'advanced' ? 'primary' : 'ghost'}`}
               onClick={() => setUiMode('advanced')}
             >
-              Advanced (YAML)
+              {t('common.advancedYamlTab')}
             </button>
           </div>
         </div>
@@ -258,7 +260,9 @@ export function ProfileProxyModal({
             {uiMode === 'visual' ? (
               <>
                 <label className="field modalField">
-                  <span className="fieldLab">Group name</span>
+                  <span className="fieldLab">
+                    {t('ui.profiles.proxyModal.groupName')}
+                  </span>
                   <input
                     className="input"
                     value={pgName}
@@ -267,7 +271,9 @@ export function ProfileProxyModal({
                   />
                 </label>
                 <label className="field modalField">
-                  <span className="fieldLab">Group type</span>
+                  <span className="fieldLab">
+                    {t('ui.profiles.proxyModal.groupType')}
+                  </span>
                   <select
                     className="selectModern"
                     value={pgType}
@@ -281,7 +287,7 @@ export function ProfileProxyModal({
                 </label>
                 <label className="field modalField">
                   <span className="fieldLab">
-                    Use providers (comma-separated)
+                    {t('ui.profiles.proxyModal.useProviders')}
                   </span>
                   <input
                     className="input"
@@ -291,7 +297,9 @@ export function ProfileProxyModal({
                   />
                 </label>
                 <label className="field modalField">
-                  <span className="fieldLab">Healthcheck URL</span>
+                  <span className="fieldLab">
+                    {t('ui.profiles.proxyModal.healthcheckUrl')}
+                  </span>
                   <input
                     className="input"
                     value={pgUrl}
@@ -301,7 +309,9 @@ export function ProfileProxyModal({
                 </label>
                 <div className="fieldGrid">
                   <label className="field modalField">
-                    <span className="fieldLab">Interval</span>
+                    <span className="fieldLab">
+                      {t('ui.profiles.proxyModal.interval')}
+                    </span>
                     <input
                       className="input"
                       value={pgInterval}
@@ -309,7 +319,9 @@ export function ProfileProxyModal({
                     />
                   </label>
                   <label className="field modalField">
-                    <span className="fieldLab">Timeout</span>
+                    <span className="fieldLab">
+                      {t('ui.profiles.proxyModal.timeout')}
+                    </span>
                     <input
                       className="input"
                       value={pgTimeout}
@@ -319,7 +331,9 @@ export function ProfileProxyModal({
                 </div>
                 <div className="fieldGrid">
                   <label className="field modalField">
-                    <span className="fieldLab">Max failed times</span>
+                    <span className="fieldLab">
+                      {t('ui.profiles.proxyModal.maxFailedTimes')}
+                    </span>
                     <input
                       className="input"
                       value={pgMaxFailed}
@@ -327,13 +341,15 @@ export function ProfileProxyModal({
                     />
                   </label>
                   <label className="field modalField">
-                    <span className="fieldLab">Lazy</span>
+                    <span className="fieldLab">
+                      {t('ui.profiles.proxyModal.lazy')}
+                    </span>
                     <button
                       type="button"
                       className={`trafficKnob ${pgLazy ? 'on' : ''}`}
                       onClick={() => setPgLazy((v) => !v)}
                     >
-                      {pgLazy ? 'On' : 'Off'}
+                      {pgLazy ? t('common.on') : t('common.off')}
                     </button>
                   </label>
                 </div>
@@ -342,7 +358,7 @@ export function ProfileProxyModal({
                   className="btn primary vergeStackBtn"
                   onClick={addGroup}
                 >
-                  Add group
+                  {t('ui.profiles.proxyModal.addGroup')}
                 </button>
                 <div className="segPill">
                   <button
@@ -350,20 +366,20 @@ export function ProfileProxyModal({
                     className={`pillOpt ${appendTarget === 'prepend' ? 'active' : ''}`}
                     onClick={() => setAppendTarget('prepend')}
                   >
-                    Prepend
+                    {t('common.prepend')}
                   </button>
                   <button
                     type="button"
                     className={`pillOpt ${appendTarget === 'append' ? 'active' : ''}`}
                     onClick={() => setAppendTarget('append')}
                   >
-                    Append
+                    {t('common.append')}
                   </button>
                 </div>
               </>
             ) : (
               <label className="field modalField">
-                <span className="fieldLab">Advanced YAML</span>
+                <span className="fieldLab">{t('common.advancedYaml')}</span>
                 <MonacoYamlEditor
                   className="vergePaneYaml modalMonacoWrap"
                   value={advancedDraft}
@@ -372,7 +388,7 @@ export function ProfileProxyModal({
                 />
                 {advancedYamlErr ? (
                   <span className="muted small" style={{ color: '#ff6b6b' }}>
-                    YAML error: {advancedYamlErr}
+                    {t('common.yamlError', { error: advancedYamlErr })}
                   </span>
                 ) : null}
               </label>
@@ -383,14 +399,16 @@ export function ProfileProxyModal({
               <p className="eyebrow">subscription.proxy-groups</p>
               <div className="vergeScrollList">
                 {baselineLoading ? (
-                  <p className="muted small">Loading subscription groups…</p>
+                  <p className="muted small">
+                    {t('ui.profiles.proxyModal.loadingGroups')}
+                  </p>
                 ) : baselineError ? (
                   <p className="muted small" style={{ color: '#ff6b6b' }}>
                     {baselineError}
                   </p>
                 ) : !baseline || baseline.length === 0 ? (
                   <p className="muted small">
-                    No subscription groups detected.
+                    {t('ui.profiles.proxyModal.noGroupsDetected')}
                   </p>
                 ) : (
                   baseline.map((gm, idx) => {
@@ -408,14 +426,20 @@ export function ProfileProxyModal({
                           <div className="vergeCardTitle">{row.name}</div>
                           <div className="muted small">{row.type}</div>
                           <div className="muted small vergeCardSub">
-                            use: {row.use || '—'}
+                            {t('ui.profiles.proxyModal.useLabel', {
+                              value: row.use || '—',
+                            })}
                           </div>
                         </div>
                         <button
                           type="button"
                           className="btn ghost vergeTrash"
-                          aria-label={isDeleted ? 'Restore' : 'Delete'}
-                          title={isDeleted ? 'Restore' : 'Delete'}
+                          aria-label={
+                            isDeleted ? t('common.restore') : t('common.delete')
+                          }
+                          title={
+                            isDeleted ? t('common.restore') : t('common.delete')
+                          }
                           onClick={() => toggleBaselineDelete(row.name)}
                         >
                           {isDeleted ? '↺' : '×'}
@@ -430,7 +454,9 @@ export function ProfileProxyModal({
               </p>
               <div className="vergeScrollList">
                 {rows.length === 0 ? (
-                  <p className="muted small">No groups yet.</p>
+                  <p className="muted small">
+                    {t('ui.profiles.proxyModal.noGroupsYet')}
+                  </p>
                 ) : (
                   rows.map((r) => (
                     <div key={r.id} className="vergeCard">
@@ -438,13 +464,15 @@ export function ProfileProxyModal({
                         <div className="vergeCardTitle">{r.name}</div>
                         <div className="muted small">{r.type}</div>
                         <div className="muted small vergeCardSub">
-                          use: {r.use || '—'}
+                          {t('ui.profiles.proxyModal.useLabel', {
+                            value: r.use || '—',
+                          })}
                         </div>
                       </div>
                       <button
                         type="button"
                         className="btn ghost vergeTrash"
-                        aria-label="Remove"
+                        aria-label={t('common.remove')}
                         onClick={() => removeRow(r.id)}
                       >
                         ×
@@ -458,7 +486,9 @@ export function ProfileProxyModal({
               </p>
               <div className="vergeScrollList">
                 {appendRows.length === 0 ? (
-                  <p className="muted small">No append groups.</p>
+                  <p className="muted small">
+                    {t('ui.profiles.proxyModal.noAppendGroups')}
+                  </p>
                 ) : (
                   appendRows.map((r) => (
                     <div key={r.id} className="vergeCard">
@@ -466,13 +496,15 @@ export function ProfileProxyModal({
                         <div className="vergeCardTitle">{r.name}</div>
                         <div className="muted small">{r.type}</div>
                         <div className="muted small vergeCardSub">
-                          use: {r.use || '—'}
+                          {t('ui.profiles.proxyModal.useLabel', {
+                            value: r.use || '—',
+                          })}
                         </div>
                       </div>
                       <button
                         type="button"
                         className="btn ghost vergeTrash"
-                        aria-label="Remove"
+                        aria-label={t('common.remove')}
                         onClick={() => removeAppendRow(r.id)}
                       >
                         ×
@@ -486,7 +518,7 @@ export function ProfileProxyModal({
         </div>
         <div className="modalFooter">
           <button type="button" className="btn ghost" onClick={onClose}>
-            Cancel
+            {t('common.cancel')}
           </button>
           <div className="modalFooterRight">
             <button
@@ -495,7 +527,7 @@ export function ProfileProxyModal({
               disabled={uiMode === 'advanced' && Boolean(advancedYamlErr)}
               onClick={() => void save()}
             >
-              Save
+              {t('common.save')}
             </button>
           </div>
         </div>

--- a/apps/sloth-clash-desktop/frontend/src/components/ProfileRulesModal.tsx
+++ b/apps/sloth-clash-desktop/frontend/src/components/ProfileRulesModal.tsx
@@ -1,4 +1,5 @@
 import { useEffect, useMemo, useState } from 'react'
+import { useTranslation } from 'react-i18next'
 
 import {
   GetProfileRulesBaseline,
@@ -83,6 +84,7 @@ export function ProfileRulesModal({
   onSaved: (banner: string) => void
   onError: (msg: string) => void
 }) {
+  const { t } = useTranslation()
   const initialRaw = target ? rulesTemplateFromProfile(profiles, target.id) : ''
   const initialBuckets = useMemo(
     () => rulesBucketsFromMerge(initialRaw),
@@ -159,7 +161,7 @@ export function ProfileRulesModal({
 
   const onSwitchToVisual = () => {
     if (advancedYamlErr) {
-      onError('Fix rules advanced YAML before switching to Visual mode.')
+      onError(t('ui.profiles.rulesModal.fixYamlBeforeVisual'))
       return
     }
     setUiMode('visual')
@@ -243,7 +245,7 @@ export function ProfileRulesModal({
           )
     try {
       await SetProfileRulesTemplate(target.id, body)
-      onSaved('Rules saved into merge template.')
+      onSaved(t('ui.profiles.rulesModal.savedBanner'))
     } catch (e: any) {
       onError(String(e))
     }
@@ -269,7 +271,7 @@ export function ProfileRulesModal({
       >
         <div className="vergeModalHead">
           <h3 id="rulesEdTitle" className="modalTitle vergeModalTitle">
-            Edit rules
+            {t('ui.profiles.rulesModal.title')}
           </h3>
           <div className="vergeToggleRow">
             <button
@@ -277,21 +279,21 @@ export function ProfileRulesModal({
               className={`btn vergeToggle ${uiMode === 'visual' ? 'primary' : 'ghost'}`}
               onClick={onSwitchToVisual}
             >
-              Visual
+              {t('common.visual')}
             </button>
             <button
               type="button"
               className={`btn vergeToggle ${uiMode === 'advanced' ? 'primary' : 'ghost'}`}
               onClick={() => setUiMode('advanced')}
             >
-              Advanced (YAML)
+              {t('common.advancedYamlTab')}
             </button>
           </div>
         </div>
 
         {uiMode === 'advanced' ? (
           <label className="field modalField rulesAdvancedField">
-            <span className="fieldLab">Advanced YAML</span>
+            <span className="fieldLab">{t('common.advancedYaml')}</span>
             <MonacoYamlEditor
               className="vergePaneYaml modalMonacoWrap"
               value={advancedDraft}
@@ -300,7 +302,7 @@ export function ProfileRulesModal({
             />
             {advancedYamlErr ? (
               <span className="rulesYamlErr small">
-                YAML error: {advancedYamlErr}
+                {t('common.yamlError', { error: advancedYamlErr })}
               </span>
             ) : null}
           </label>
@@ -311,7 +313,7 @@ export function ProfileRulesModal({
                 className="selectModern selectInline rulesAddType"
                 value={formType}
                 onChange={(e) => setFormType(e.target.value)}
-                aria-label="Rule type"
+                aria-label={t('ui.profiles.rulesModal.ruleTypeAria')}
               >
                 {RULE_TYPE_OPTIONS.map((type) => (
                   <option key={type} value={type}>
@@ -324,7 +326,9 @@ export function ProfileRulesModal({
                 value={formContent}
                 onChange={(e) => setFormContent(e.target.value)}
                 placeholder={
-                  formType === 'MATCH' ? '(no content)' : 'google.com'
+                  formType === 'MATCH'
+                    ? t('ui.profiles.rulesModal.noContentPlaceholder')
+                    : 'google.com'
                 }
                 disabled={formType === 'MATCH'}
                 onKeyDown={(e) => {
@@ -338,7 +342,7 @@ export function ProfileRulesModal({
                 className="selectModern selectInline rulesAddPolicy"
                 value={formPolicy}
                 onChange={(e) => setFormPolicy(e.target.value)}
-                aria-label="Proxy policy"
+                aria-label={t('ui.profiles.rulesModal.policyAria')}
               >
                 {policyOptions.map((opt) => (
                   <option key={opt} value={opt}>
@@ -352,14 +356,14 @@ export function ProfileRulesModal({
                   className={`pillOpt ${appendTarget === 'prepend' ? 'active' : ''}`}
                   onClick={() => setAppendTarget('prepend')}
                 >
-                  Prepend
+                  {t('common.prepend')}
                 </button>
                 <button
                   type="button"
                   className={`pillOpt ${appendTarget === 'append' ? 'active' : ''}`}
                   onClick={() => setAppendTarget('append')}
                 >
-                  Append
+                  {t('common.append')}
                 </button>
               </div>
               <button
@@ -367,16 +371,20 @@ export function ProfileRulesModal({
                 className="btn primary rulesAddBtn"
                 onClick={addRule}
               >
-                + Add
+                {t('common.addShort')}
               </button>
             </div>
 
             <div className="rulesCols">
               <div className="rulesCol">
-                <p className="eyebrow">Your rules</p>
+                <p className="eyebrow">
+                  {t('ui.profiles.rulesModal.yourRules')}
+                </p>
                 <div className="rulesList">
                   {!hasCustom ? (
-                    <p className="muted small">No custom rules yet.</p>
+                    <p className="muted small">
+                      {t('ui.profiles.rulesModal.noCustomRules')}
+                    </p>
                   ) : null}
                   {rows.map((r) => (
                     <RuleLine
@@ -385,7 +393,7 @@ export function ProfileRulesModal({
                       content={r.content}
                       policy={r.policy}
                       pos="prepend"
-                      actionLabel="Remove"
+                      actionLabel={t('common.remove')}
                       actionGlyph="×"
                       onAction={() => removeRow(r.id)}
                     />
@@ -397,7 +405,7 @@ export function ProfileRulesModal({
                       content={r.content}
                       policy={r.policy}
                       pos="append"
-                      actionLabel="Remove"
+                      actionLabel={t('common.remove')}
                       actionGlyph="×"
                       onAction={() => removeAppendRow(r.id)}
                     />
@@ -406,15 +414,19 @@ export function ProfileRulesModal({
               </div>
 
               <div className="rulesCol">
-                <p className="eyebrow">Subscription · read-only</p>
+                <p className="eyebrow">
+                  {t('ui.profiles.rulesModal.subscriptionReadOnly')}
+                </p>
                 <div className="rulesList">
                   {baselineLoading ? (
-                    <p className="muted small">Loading subscription rules…</p>
+                    <p className="muted small">
+                      {t('ui.profiles.rulesModal.loadingRules')}
+                    </p>
                   ) : baselineError ? (
                     <p className="muted small rulesYamlErr">{baselineError}</p>
                   ) : !baseline || baseline.length === 0 ? (
                     <p className="muted small">
-                      No subscription rules detected.
+                      {t('ui.profiles.rulesModal.noRulesDetected')}
                     </p>
                   ) : (
                     baseline.map((line, idx) => {
@@ -427,7 +439,9 @@ export function ProfileRulesModal({
                           content={parsed.content}
                           policy={parsed.policy}
                           deleted={isDeleted}
-                          actionLabel={isDeleted ? 'Restore' : 'Delete'}
+                          actionLabel={
+                            isDeleted ? t('common.restore') : t('common.delete')
+                          }
                           actionGlyph={isDeleted ? '↺' : '×'}
                           onAction={() => toggleBaselineDelete(line)}
                         />
@@ -442,7 +456,7 @@ export function ProfileRulesModal({
 
         <div className="modalFooter">
           <button type="button" className="btn ghost" onClick={onClose}>
-            Cancel
+            {t('common.cancel')}
           </button>
           <div className="modalFooterRight">
             <button
@@ -451,7 +465,7 @@ export function ProfileRulesModal({
               disabled={uiMode === 'advanced' && Boolean(advancedYamlErr)}
               onClick={() => void save()}
             >
-              Save
+              {t('common.save')}
             </button>
           </div>
         </div>

--- a/apps/sloth-clash-desktop/frontend/src/components/SettingsResetModal.tsx
+++ b/apps/sloth-clash-desktop/frontend/src/components/SettingsResetModal.tsx
@@ -1,3 +1,5 @@
+import { useTranslation } from 'react-i18next'
+
 export type SettingsResetMode = 'keep_profiles' | 'with_profiles'
 
 export function SettingsResetModal({
@@ -9,6 +11,7 @@ export function SettingsResetModal({
   onClose: () => void
   onConfirm: (withProfiles: boolean) => void
 }) {
+  const { t } = useTranslation()
   if (!mode) return null
   return (
     <div
@@ -25,24 +28,24 @@ export function SettingsResetModal({
         onClick={(e) => e.stopPropagation()}
       >
         <h3 id="resetSettingsTitle" className="modalTitle">
-          Reset app settings
+          {t('settings.resetModal.title')}
         </h3>
         <p className="muted small">
           {mode === 'with_profiles'
-            ? 'Reset settings and delete all profiles from this device?'
-            : 'Reset UI settings and local defaults, but keep profiles?'}
+            ? t('settings.resetModal.withProfilesBody')
+            : t('settings.resetModal.keepProfilesBody')}
         </p>
         <div className="modalFooter">
           <div className="modalFooterRight" style={{ width: '100%' }}>
             <button type="button" className="btn ghost" onClick={onClose}>
-              Cancel
+              {t('common.cancel')}
             </button>
             <button
               type="button"
               className="btn primary"
               onClick={() => onConfirm(mode === 'with_profiles')}
             >
-              Reset
+              {t('settings.resetModal.reset')}
             </button>
           </div>
         </div>

--- a/apps/sloth-clash-desktop/frontend/src/locales/en.json
+++ b/apps/sloth-clash-desktop/frontend/src/locales/en.json
@@ -65,7 +65,13 @@
     "updateAvailable": "Update available: {{version}}",
     "upToDate": "You are on the latest release.",
     "downloadInstaller": "Download & install update",
-    "openReleasePage": "Open release page"
+    "openReleasePage": "Open release page",
+    "resetModal": {
+      "title": "Reset app settings",
+      "keepProfilesBody": "Reset UI settings and local defaults, but keep profiles?",
+      "withProfilesBody": "Reset settings and delete all profiles from this device?",
+      "reset": "Reset"
+    }
   },
   "tour": {
     "back": "Back",
@@ -150,7 +156,97 @@
       "refreshSubscription": "Refresh subscription",
       "localNoUrl": "Local / no URL",
       "active": "Active",
-      "activate": "Activate"
+      "activate": "Activate",
+      "contextMenu": {
+        "updateNow": "Update profile now",
+        "editInfo": "Edit info",
+        "copySubscriptionUrl": "Copy subscription URL",
+        "rules": "Rules",
+        "deleteProfile": "Delete profile",
+        "advanced": "Advanced",
+        "extendConfig": "Extend config",
+        "proxyGroups": "Proxy groups",
+        "editFile": "Edit file"
+      },
+      "importModal": {
+        "tabUrl": "Subscription URL",
+        "tabPaste": "Paste / File",
+        "subscriptionUrl": "Subscription URL",
+        "configOrLinks": "Config or share links",
+        "detectYaml": "Clash YAML config",
+        "detectLinksSingular": "{{count}} share link",
+        "detectLinksPlural": "{{count}} share links",
+        "detectLinksBase64Singular": "{{count}} share link (base64)",
+        "detectLinksBase64Plural": "{{count}} share links (base64)",
+        "detectUnknown": "Unrecognized — expecting Clash YAML or vless:// / vmess:// / ss:// / trojan:// links",
+        "pastePlaceholder": "Paste a mihomo/Clash config.yaml,\nor share links — one per line:\nvless://…\nvmess://…\ntrojan://…",
+        "displayName": "Display name",
+        "namePlaceholderUrl": "Empty = use Profile-Title from server",
+        "namePlaceholderPaste": "Empty = \"Local config\"",
+        "pasteFromClipboard": "Paste from clipboard",
+        "loadFromFile": "Load from file…"
+      },
+      "editInfo": {
+        "title": "Edit profile info",
+        "blurb": "Display name and subscription link. Leave the URL field empty to keep the current link unchanged.",
+        "name": "Name",
+        "subscriptionUrl": "Subscription URL",
+        "urlPlaceholder": "Leave empty to keep current",
+        "autoUpdate": "Auto-update",
+        "intervalMinutes": "Interval (minutes)",
+        "copyUrl": "Copy URL",
+        "copyName": "Copy name"
+      },
+      "fileModal": {
+        "title": "Edit configuration file",
+        "loadedConfig": "· loaded config.yaml",
+        "readErrorLead": "Read: {{error}} — you can still paste YAML and save to create the file.",
+        "copyPath": "Copy path"
+      },
+      "mergeModal": {
+        "title": "Profile merge template",
+        "blurbLead": "Top-level keys merge into the fetched profile;",
+        "blurbTail": "for rules, proxy-groups, and provider maps. Applied whenever Sloth writes",
+        "mergeYaml": "· merge YAML",
+        "resetScaffold": "Reset scaffold"
+      },
+      "proxyModal": {
+        "title": "Edit proxy groups",
+        "groupName": "Group name",
+        "groupType": "Group type",
+        "useProviders": "Use providers (comma-separated)",
+        "healthcheckUrl": "Healthcheck URL",
+        "interval": "Interval",
+        "timeout": "Timeout",
+        "maxFailedTimes": "Max failed times",
+        "lazy": "Lazy",
+        "addGroup": "Add group",
+        "loadingGroups": "Loading subscription groups…",
+        "noGroupsDetected": "No subscription groups detected.",
+        "noGroupsYet": "No groups yet.",
+        "noAppendGroups": "No append groups.",
+        "useLabel": "use: {{value}}",
+        "fixYamlBeforeVisual": "Fix proxy advanced YAML before switching to Visual mode.",
+        "savedBanner": "Proxy groups saved into merge template."
+      },
+      "rulesModal": {
+        "title": "Edit rules",
+        "ruleTypeAria": "Rule type",
+        "noContentPlaceholder": "(no content)",
+        "policyAria": "Proxy policy",
+        "yourRules": "Your rules",
+        "noCustomRules": "No custom rules yet.",
+        "subscriptionReadOnly": "Subscription · read-only",
+        "loadingRules": "Loading subscription rules…",
+        "noRulesDetected": "No subscription rules detected.",
+        "fixYamlBeforeVisual": "Fix rules advanced YAML before switching to Visual mode.",
+        "savedBanner": "Rules saved into merge template."
+      },
+      "deleteModal": {
+        "title": "Delete profile",
+        "bodyPrefix": "Remove",
+        "bodySuffix": "from this device? This does not cancel a remote subscription."
+      }
     },
     "proxies": {
       "title": "Proxies",
@@ -305,6 +401,21 @@
     "no": "No",
     "close": "Close",
     "show": "Show",
-    "hide": "Hide"
+    "hide": "Hide",
+    "cancel": "Cancel",
+    "save": "Save",
+    "delete": "Delete",
+    "reset": "Reset",
+    "import": "Import",
+    "remove": "Remove",
+    "restore": "Restore",
+    "optional": "(optional)",
+    "yamlError": "YAML error: {{error}}",
+    "visual": "Visual",
+    "advancedYamlTab": "Advanced (YAML)",
+    "advancedYaml": "Advanced YAML",
+    "prepend": "Prepend",
+    "append": "Append",
+    "addShort": "+ Add"
   }
 }

--- a/apps/sloth-clash-desktop/frontend/src/locales/ru.json
+++ b/apps/sloth-clash-desktop/frontend/src/locales/ru.json
@@ -65,7 +65,13 @@
     "updateAvailable": "Доступно обновление: {{version}}",
     "upToDate": "Установлена последняя версия.",
     "downloadInstaller": "Скачать и установить",
-    "openReleasePage": "Страница релиза"
+    "openReleasePage": "Страница релиза",
+    "resetModal": {
+      "title": "Сброс настроек приложения",
+      "keepProfilesBody": "Сбросить настройки интерфейса и локальные значения по умолчанию, но сохранить профили?",
+      "withProfilesBody": "Сбросить настройки и удалить все профили с этого устройства?",
+      "reset": "Сбросить"
+    }
   },
   "tour": {
     "back": "Назад",
@@ -150,7 +156,97 @@
       "refreshSubscription": "Обновить подписку",
       "localNoUrl": "Локальный / без URL",
       "active": "Активен",
-      "activate": "Активировать"
+      "activate": "Активировать",
+      "contextMenu": {
+        "updateNow": "Обновить профиль сейчас",
+        "editInfo": "Изменить сведения",
+        "copySubscriptionUrl": "Копировать URL подписки",
+        "rules": "Правила",
+        "deleteProfile": "Удалить профиль",
+        "advanced": "Дополнительно",
+        "extendConfig": "Расширить конфиг",
+        "proxyGroups": "Группы прокси",
+        "editFile": "Редактировать файл"
+      },
+      "importModal": {
+        "tabUrl": "URL подписки",
+        "tabPaste": "Вставка / файл",
+        "subscriptionUrl": "URL подписки",
+        "configOrLinks": "Конфиг или share-ссылки",
+        "detectYaml": "Clash YAML конфиг",
+        "detectLinksSingular": "{{count}} share-ссылка",
+        "detectLinksPlural": "{{count}} share-ссылок",
+        "detectLinksBase64Singular": "{{count}} share-ссылка (base64)",
+        "detectLinksBase64Plural": "{{count}} share-ссылок (base64)",
+        "detectUnknown": "Не распознано — ожидается Clash YAML или ссылки vless:// / vmess:// / ss:// / trojan://",
+        "pastePlaceholder": "Вставьте mihomo/Clash config.yaml\nили share-ссылки — по одной на строку:\nvless://…\nvmess://…\ntrojan://…",
+        "displayName": "Отображаемое имя",
+        "namePlaceholderUrl": "Пусто = использовать Profile-Title с сервера",
+        "namePlaceholderPaste": "Пусто = «Локальный конфиг»",
+        "pasteFromClipboard": "Вставить из буфера",
+        "loadFromFile": "Загрузить из файла…"
+      },
+      "editInfo": {
+        "title": "Изменить сведения профиля",
+        "blurb": "Отображаемое имя и ссылка подписки. Оставьте поле URL пустым, чтобы сохранить текущую ссылку.",
+        "name": "Имя",
+        "subscriptionUrl": "URL подписки",
+        "urlPlaceholder": "Оставьте пустым, чтобы сохранить текущий",
+        "autoUpdate": "Автообновление",
+        "intervalMinutes": "Интервал (минуты)",
+        "copyUrl": "Копировать URL",
+        "copyName": "Копировать имя"
+      },
+      "fileModal": {
+        "title": "Редактировать файл конфигурации",
+        "loadedConfig": "· загружен config.yaml",
+        "readErrorLead": "Чтение: {{error}} — можно вставить YAML и сохранить, чтобы создать файл.",
+        "copyPath": "Копировать путь"
+      },
+      "mergeModal": {
+        "title": "Шаблон merge профиля",
+        "blurbLead": "Ключи верхнего уровня объединяются с загруженным профилем;",
+        "blurbTail": "для rules, proxy-groups и provider maps. Применяется при каждой записи Sloth в",
+        "mergeYaml": "· merge YAML",
+        "resetScaffold": "Сбросить шаблон"
+      },
+      "proxyModal": {
+        "title": "Редактировать группы прокси",
+        "groupName": "Имя группы",
+        "groupType": "Тип группы",
+        "useProviders": "Провайдеры (через запятую)",
+        "healthcheckUrl": "URL проверки",
+        "interval": "Интервал",
+        "timeout": "Таймаут",
+        "maxFailedTimes": "Макс. неудач",
+        "lazy": "Lazy",
+        "addGroup": "Добавить группу",
+        "loadingGroups": "Загрузка групп подписки…",
+        "noGroupsDetected": "Группы подписки не обнаружены.",
+        "noGroupsYet": "Групп пока нет.",
+        "noAppendGroups": "Нет append-групп.",
+        "useLabel": "use: {{value}}",
+        "fixYamlBeforeVisual": "Исправьте advanced YAML прокси перед переключением в Visual режим.",
+        "savedBanner": "Группы прокси сохранены в merge-шаблон."
+      },
+      "rulesModal": {
+        "title": "Редактировать правила",
+        "ruleTypeAria": "Тип правила",
+        "noContentPlaceholder": "(без содержимого)",
+        "policyAria": "Политика прокси",
+        "yourRules": "Ваши правила",
+        "noCustomRules": "Пользовательских правил пока нет.",
+        "subscriptionReadOnly": "Подписка · только чтение",
+        "loadingRules": "Загрузка правил подписки…",
+        "noRulesDetected": "Правила подписки не обнаружены.",
+        "fixYamlBeforeVisual": "Исправьте advanced YAML правил перед переключением в Visual режим.",
+        "savedBanner": "Правила сохранены в merge-шаблон."
+      },
+      "deleteModal": {
+        "title": "Удалить профиль",
+        "bodyPrefix": "Удалить",
+        "bodySuffix": "с этого устройства? Это не отменяет удалённую подписку."
+      }
     },
     "proxies": {
       "title": "Прокси",
@@ -305,6 +401,21 @@
     "no": "Нет",
     "close": "Закрыть",
     "show": "Показать",
-    "hide": "Скрыть"
+    "hide": "Скрыть",
+    "cancel": "Отмена",
+    "save": "Сохранить",
+    "delete": "Удалить",
+    "reset": "Сбросить",
+    "import": "Импорт",
+    "remove": "Убрать",
+    "restore": "Восстановить",
+    "optional": "(необязательно)",
+    "yamlError": "Ошибка YAML: {{error}}",
+    "visual": "Visual",
+    "advancedYamlTab": "Advanced (YAML)",
+    "advancedYaml": "Advanced YAML",
+    "prepend": "Prepend",
+    "append": "Append",
+    "addShort": "+ Добавить"
   }
 }

--- a/apps/sloth-clash-desktop/frontend/src/locales/zh.json
+++ b/apps/sloth-clash-desktop/frontend/src/locales/zh.json
@@ -65,7 +65,13 @@
     "updateAvailable": "有可用更新：{{version}}",
     "upToDate": "已是最新版本。",
     "downloadInstaller": "下载并安装更新",
-    "openReleasePage": "打开发布页"
+    "openReleasePage": "打开发布页",
+    "resetModal": {
+      "title": "重置应用设置",
+      "keepProfilesBody": "重置界面设置和本地默认值，但保留配置？",
+      "withProfilesBody": "重置设置并从此设备删除所有配置？",
+      "reset": "重置"
+    }
   },
   "tour": {
     "back": "上一步",
@@ -150,7 +156,97 @@
       "refreshSubscription": "刷新订阅",
       "localNoUrl": "本地 / 无 URL",
       "active": "当前使用",
-      "activate": "设为当前"
+      "activate": "设为当前",
+      "contextMenu": {
+        "updateNow": "立即更新配置",
+        "editInfo": "编辑信息",
+        "copySubscriptionUrl": "复制订阅 URL",
+        "rules": "规则",
+        "deleteProfile": "删除配置",
+        "advanced": "高级",
+        "extendConfig": "扩展配置",
+        "proxyGroups": "代理分组",
+        "editFile": "编辑文件"
+      },
+      "importModal": {
+        "tabUrl": "订阅 URL",
+        "tabPaste": "粘贴 / 文件",
+        "subscriptionUrl": "订阅 URL",
+        "configOrLinks": "配置或分享链接",
+        "detectYaml": "Clash YAML 配置",
+        "detectLinksSingular": "{{count}} 条分享链接",
+        "detectLinksPlural": "{{count}} 条分享链接",
+        "detectLinksBase64Singular": "{{count}} 条分享链接 (base64)",
+        "detectLinksBase64Plural": "{{count}} 条分享链接 (base64)",
+        "detectUnknown": "无法识别 — 需要 Clash YAML 或 vless:// / vmess:// / ss:// / trojan:// 链接",
+        "pastePlaceholder": "粘贴 mihomo/Clash config.yaml，\n或分享链接 — 每行一条：\nvless://…\nvmess://…\ntrojan://…",
+        "displayName": "显示名称",
+        "namePlaceholderUrl": "留空 = 使用服务端 Profile-Title",
+        "namePlaceholderPaste": "留空 = “本地配置”",
+        "pasteFromClipboard": "从剪贴板粘贴",
+        "loadFromFile": "从文件加载…"
+      },
+      "editInfo": {
+        "title": "编辑配置信息",
+        "blurb": "显示名称与订阅链接。URL 留空则保持当前链接不变。",
+        "name": "名称",
+        "subscriptionUrl": "订阅 URL",
+        "urlPlaceholder": "留空以保持当前链接",
+        "autoUpdate": "自动更新",
+        "intervalMinutes": "间隔（分钟）",
+        "copyUrl": "复制 URL",
+        "copyName": "复制名称"
+      },
+      "fileModal": {
+        "title": "编辑配置文件",
+        "loadedConfig": "· 已加载 config.yaml",
+        "readErrorLead": "读取：{{error}} — 仍可粘贴 YAML 并保存以创建文件。",
+        "copyPath": "复制路径"
+      },
+      "mergeModal": {
+        "title": "配置合并模板",
+        "blurbLead": "顶层键会合并到拉取的配置中；",
+        "blurbTail": "用于 rules、proxy-groups 与 provider maps。Sloth 写入",
+        "mergeYaml": "· merge YAML",
+        "resetScaffold": "重置模板"
+      },
+      "proxyModal": {
+        "title": "编辑代理分组",
+        "groupName": "分组名称",
+        "groupType": "分组类型",
+        "useProviders": "使用提供者（逗号分隔）",
+        "healthcheckUrl": "健康检查 URL",
+        "interval": "间隔",
+        "timeout": "超时",
+        "maxFailedTimes": "最大失败次数",
+        "lazy": "Lazy",
+        "addGroup": "添加分组",
+        "loadingGroups": "正在加载订阅分组…",
+        "noGroupsDetected": "未检测到订阅分组。",
+        "noGroupsYet": "尚无分组。",
+        "noAppendGroups": "无 append 分组。",
+        "useLabel": "use: {{value}}",
+        "fixYamlBeforeVisual": "切换到 Visual 前请先修复代理 advanced YAML。",
+        "savedBanner": "代理分组已保存到 merge 模板。"
+      },
+      "rulesModal": {
+        "title": "编辑规则",
+        "ruleTypeAria": "规则类型",
+        "noContentPlaceholder": "（无内容）",
+        "policyAria": "代理策略",
+        "yourRules": "你的规则",
+        "noCustomRules": "尚无自定义规则。",
+        "subscriptionReadOnly": "订阅 · 只读",
+        "loadingRules": "正在加载订阅规则…",
+        "noRulesDetected": "未检测到订阅规则。",
+        "fixYamlBeforeVisual": "切换到 Visual 前请先修复规则 advanced YAML。",
+        "savedBanner": "规则已保存到 merge 模板。"
+      },
+      "deleteModal": {
+        "title": "删除配置",
+        "bodyPrefix": "从本设备移除",
+        "bodySuffix": "？这不会取消远程订阅。"
+      }
     },
     "proxies": {
       "title": "代理",
@@ -305,6 +401,21 @@
     "no": "否",
     "close": "关闭",
     "show": "显示",
-    "hide": "隐藏"
+    "hide": "隐藏",
+    "cancel": "取消",
+    "save": "保存",
+    "delete": "删除",
+    "reset": "重置",
+    "import": "导入",
+    "remove": "移除",
+    "restore": "恢复",
+    "optional": "（可选）",
+    "yamlError": "YAML 错误：{{error}}",
+    "visual": "Visual",
+    "advancedYamlTab": "Advanced (YAML)",
+    "advancedYaml": "Advanced YAML",
+    "prepend": "Prepend",
+    "append": "Append",
+    "addShort": "+ 添加"
   }
 }


### PR DESCRIPTION
Route 9 profile/settings modal components plus the profile context menu through useTranslation; add ~100 keys to en/zh/ru with real zh/ru translations. Clash-domain terms (prepend/append/YAML) left in English by design. FlagMark/ToastHub/Proxies untouched (Proxies pending redesign). typecheck + lint green.