### PR TITLE
fix(connect): skip redundant startup reload after cold start

### DIFF
--- a/apps/sloth-clash-desktop/app.go
+++ b/apps/sloth-clash-desktop/app.go
@@ -153,7 +153,8 @@ func (a *App) bootActiveProfileCoreInBackground() {
 	// Connect() will bring TUN up via applyRuntimeConfig+PUT /configs force-reload
 	// (matches clash-verge-rev's init path: start_core with current verge state,
 	// then toggle_tun_mode goes through update_config → reload_config).
-	if err := a.ensureCoreForProfile(profile, 0, false); err != nil {
+	coldStarted, err := a.ensureCoreForProfileEx(profile, 0, false)
+	if err != nil {
 		debugLog(
 			"startup",
 			"H1",
@@ -166,10 +167,17 @@ func (a *App) bootActiveProfileCoreInBackground() {
 		)
 		return
 	}
-	// If a core survived an unclean OS shutdown (or was already started by the
-	// service), ensureCoreForProfile may early-return without touching tun.enable.
-	// Force a runtime YAML sync with enableTun=false so UI "disconnected" and
-	// actual network state stay aligned on startup.
+	// Only sync the runtime config when the core was REUSED (survived an unclean
+	// OS shutdown / was already started by the service) — there its actual TUN
+	// state may not match "disconnected", so we force tun.enable=false to realign.
+	// A FRESH cold start already loaded the generated YAML (tun.enable=false baked
+	// in by startEmbeddedCore), so re-applying it here would just trigger a second
+	// full provider re-pull for no behaviour change — the redundant pull that made
+	// Connect drag on heavy/unhealthy-provider profiles. Mirrors runConnectJob's
+	// own cold-start skip.
+	if coldStarted {
+		return
+	}
 	if err := a.applyRuntimeConfig(profile, traffic, false); err != nil {
 		debugLog(
 			"startup",

--- a/apps/sloth-clash-desktop/config_parity_test.go
+++ b/apps/sloth-clash-desktop/config_parity_test.go
@@ -72,7 +72,8 @@ func TestConfigParitySubscriptionBlocksPreserved(t *testing.T) {
 
 	d := dnsMap(t, m)
 
-	// DNS listen: default to :1053 (verge parity), never loopback.
+	// DNS listen: default :1053 (all interfaces, real fixed port — verge parity).
+	// Loopback breaks TUN dns-hijack; an ephemeral :0 listen did not work for users.
 	if d["listen"] != ":1053" {
 		t.Errorf("dns.listen = %v, want :1053", d["listen"])
 	}

--- a/apps/sloth-clash-desktop/dns_listen_test.go
+++ b/apps/sloth-clash-desktop/dns_listen_test.go
@@ -11,7 +11,8 @@ func TestEnsureDefaultDNSForTunListenDefault(t *testing.T) {
 	m := map[string]any{"dns": map[string]any{"enable": true}}
 	ensureDefaultDNSForTun(m)
 	dns := m["dns"].(map[string]any)
-	// Byte-for-byte parity with clash-verge-rev: ":1053" (all interfaces).
+	// Default :1053 (all interfaces, real fixed port — verge parity). Loopback
+	// breaks TUN dns-hijack; an ephemeral :0 listen did not work for users.
 	if dns["listen"] != ":1053" {
 		t.Fatalf("listen default = %v, want :1053", dns["listen"])
 	}

--- a/apps/sloth-clash-desktop/subscription_overlay.go
+++ b/apps/sloth-clash-desktop/subscription_overlay.go
@@ -56,15 +56,16 @@ func ensureDefaultDNSForTun(m map[string]any) {
 	if _, ok := dns["enable"]; !ok {
 		dns["enable"] = true
 	}
-	// DNS listener default: byte-for-byte parity with clash-verge-rev — `:1053`
-	// (all interfaces, IPv4+IPv6, fixed port 1053). Parity is deliberate: verge's
-	// generated config works flawlessly in the field, so every divergence on our
-	// side is a latent bug — the original loopback-only `127.0.0.1:0` bind proved
-	// it (unreachable for TUN `dns-hijack: any:53`, DNS died under TUN while
-	// system-proxy kept working). A random port was a divergence solving a
-	// non-problem (two Clash clients never run at once), so we dropped it.
-	// Only fill a default when the config/extended-config did not set one, so an
-	// explicit `dns.listen` is honoured instead of clobbered.
+	// DNS listener default: `:1053` (all interfaces, a REAL fixed port) — matches
+	// clash-verge-rev, which works reliably in the field. Hard requirements learned
+	// from real users:
+	//   - NOT loopback-only (`127.0.0.1`): unreachable for TUN `dns-hijack: any:53`
+	//     on Windows → DNS dies under TUN while system-proxy keeps working.
+	//   - A REAL fixed port, NOT `:0`/ephemeral: a `0.0.0.0:0` listen did NOT work
+	//     for a user (no resolution), while verge's `:1053` worked instantly.
+	// We only fill this DEFAULT when the subscription/extended config did not set
+	// its own `dns.listen`. An explicit value (e.g. the subscription's own `:1053`)
+	// is honoured, never clobbered — same as verge.
 	if v, ok := dns["listen"].(string); !ok || strings.TrimSpace(v) == "" {
 		dns["listen"] = ":1053"
 	}


### PR DESCRIPTION
bootActiveProfileCoreInBackground cold-started the core (loads config + pulls all providers) then immediately force-reloaded the same config, re-pulling every provider a second time -> slow Connect on heavy/unhealthy-provider subs. Skip the sync reload on a fresh cold start (ensureCoreForProfileEx coldStarted); still sync a reused/surviving core. Also clarifies the dns.listen :1053 rationale in comments (a :0 listen did not work for users).