### PR TITLE
fix(tun): force hardened tun base over subscription

### DIFF
--- a/apps/sloth-clash-desktop/config_parity_test.go
+++ b/apps/sloth-clash-desktop/config_parity_test.go
@@ -94,13 +94,21 @@ func TestConfigParitySubscriptionBlocksPreserved(t *testing.T) {
 		t.Errorf("respect-rules = %v, want true (preserved)", d["respect-rules"])
 	}
 
-	// TUN: subscription block preserved; only enable is overwritten to intent.
+	// TUN: we force the hardened tun base OVER the subscription. The input ships
+	// stack: mixed + strict-route: true; both must be overridden. strict-route
+	// MUST be false — a subscription strict-route: true loops the core's own
+	// DNS/proxy traffic back into the TUN under the system service and kills
+	// proxy-node resolution (only DIRECT survives). Locked here so it can never
+	// regress.
 	tun, ok := m["tun"].(map[string]any)
 	if !ok {
 		t.Fatalf("tun block missing: %#v", m["tun"])
 	}
-	if tun["stack"] != "mixed" {
-		t.Errorf("tun.stack = %v, want mixed (preserved from subscription)", tun["stack"])
+	if tun["strict-route"] != false {
+		t.Errorf("tun.strict-route = %v, want false (forced over subscription)", tun["strict-route"])
+	}
+	if tun["stack"] != "gvisor" {
+		t.Errorf("tun.stack = %v, want gvisor (forced over subscription)", tun["stack"])
 	}
 	if tun["enable"] != true {
 		t.Errorf("tun.enable = %v, want true (overwritten to traffic intent)", tun["enable"])

--- a/apps/sloth-clash-desktop/frontend/wailsjs/go/models.ts
+++ b/apps/sloth-clash-desktop/frontend/wailsjs/go/models.ts
@@ -346,6 +346,18 @@ export namespace main {
       return a
     }
   }
+  export class AppUpdateSettings {
+    autoCheckEnabled?: boolean
+
+    static createFrom(source: any = {}) {
+      return new AppUpdateSettings(source)
+    }
+
+    constructor(source: any = {}) {
+      if ('string' === typeof source) source = JSON.parse(source)
+      this.autoCheckEnabled = source['autoCheckEnabled']
+    }
+  }
   export class ConnectionMeta {
     network?: string
     type?: string
@@ -515,6 +527,7 @@ export namespace main {
     tun: TunSettings
     traffic: TrafficSettings
     privacy: PrivacySettings
+    appUpdate: AppUpdateSettings
     lang?: string
 
     static createFrom(source: any = {}) {
@@ -526,6 +539,10 @@ export namespace main {
       this.tun = this.convertValues(source['tun'], TunSettings)
       this.traffic = this.convertValues(source['traffic'], TrafficSettings)
       this.privacy = this.convertValues(source['privacy'], PrivacySettings)
+      this.appUpdate = this.convertValues(
+        source['appUpdate'],
+        AppUpdateSettings,
+      )
       this.lang = source['lang']
     }
 
@@ -737,6 +754,7 @@ export namespace main {
     currentVersion?: string
     latestVersion?: string
     releaseUrl?: string
+    releaseNotes?: string
     assetName?: string
     assetDownloadUrl?: string
     lastError?: string
@@ -753,6 +771,7 @@ export namespace main {
       this.currentVersion = source['currentVersion']
       this.latestVersion = source['latestVersion']
       this.releaseUrl = source['releaseUrl']
+      this.releaseNotes = source['releaseNotes']
       this.assetName = source['assetName']
       this.assetDownloadUrl = source['assetDownloadUrl']
       this.lastError = source['lastError']

--- a/apps/sloth-clash-desktop/subscription_overlay.go
+++ b/apps/sloth-clash-desktop/subscription_overlay.go
@@ -121,25 +121,25 @@ func ensureDefaultDNSForTun(m map[string]any) {
 	m["dns"] = dns
 }
 
-// ensureTunOverlayForTraffic installs or hardens the TUN block in the generated
+// ensureTunOverlayForTraffic installs and hardens the TUN block in the generated
 // runtime config. The enableTun argument is written verbatim to tun.enable, so
 // callers are expected to pass the effective user intent (connected && traffic=="tun").
-// This mirrors clash-verge-rev's enhance::tun::use_tun + IClashTemp::template():
 //
-//   - If the subscription or extended config already ships a `tun:` block we
-//     trust its stack / auto-route / dns-hijack / mtu values verbatim (same as
-//     Verge Rev's `append!` semantics in the template).
-//   - If no `tun:` block is present we install the default template (gvisor,
-//     auto-route, strict-route=false, dns-hijack=[any:53]).
-//   - Only `tun.enable` is overwritten every time, so PUT /configs?force=true
-//     stays idempotent across hot reloads.
+// We OVERWRITE a hardened base set (stack=gvisor, auto-route, auto-detect-interface,
+// strict-route=false, dns-hijack=[any:53]) on top of whatever the subscription
+// ships — we do NOT trust the subscription's tun verbatim. A subscription can ship
+// tun options that break routing/egress; most importantly strict-route=true, which
+// forces the core's own DNS/proxy traffic back into the TUN under the system-service
+// core and kills proxy-node resolution (only DIRECT survives — proven in the field).
+// Keys the subscription adds beyond the base (route-exclude-address, mtu, device)
+// are preserved, and the user can still override any field via Settings → TUN
+// (applyUserTunOverlay runs after this). tun.enable is set every time so
+// PUT /configs?force=true stays idempotent across hot reloads.
 //
-// Previously this function forced stack=system and added tcp://any:53 on
-// Windows. That hurt UDP-heavy traffic (games) because Mihomo's kernel stack
-// is more sensitive to wintun ring-buffer pressure than gvisor, and the extra
-// TCP hijack caused double-handling of DNS. Both have been removed to track
-// upstream verbatim — users who need a different stack can override through
-// the subscription / extended config / Settings → TUN UI.
+// History: this used to trust the subscription's tun verbatim and overwrite only
+// tun.enable, which let strict-route=true through and caused the dead-proxy bug;
+// and before that it forced stack=system + tcp://any:53, which hurt UDP-heavy
+// traffic on wintun. Both are gone.
 func ensureTunOverlayForTraffic(m map[string]any, enableTun bool) {
 	rawTun, has := m["tun"].(map[string]any)
 	if !has || rawTun == nil {
@@ -150,19 +150,23 @@ func ensureTunOverlayForTraffic(m map[string]any, enableTun bool) {
 		}
 	}
 
-	rawTun["enable"] = enableTun
-	// Force strict-route OFF, overriding whatever the subscription shipped. This
-	// matches clash-verge-rev, whose base tun template overwrites the
-	// subscription's tun fields (its default strict-route is false). A
-	// subscription with strict-route: true breaks ALL proxied traffic when the
-	// core runs under our SYSTEM / session-0 service: strict-route forces the
-	// core's OWN outbound (upstream DNS + proxy-node dials) back through the TUN,
-	// so proxy nodes never resolve ("couldn't find ip") and only DIRECT works —
-	// while verge (strict-route: false) resolves fine. Proven on a real user
-	// machine: flipping this to false fixes it. A user who really wants strict
-	// routing can still set it via Settings → TUN (applyUserTunOverlay runs after
-	// this and wins).
+	// Overwrite the whole hardened tun base over whatever the subscription ships,
+	// so no subscription can ship a tun option that breaks routing/egress. Most
+	// critically strict-route MUST stay false: a subscription shipping
+	// strict-route: true forces the core's OWN outbound (upstream DNS + proxy-node
+	// dials) back into the TUN when the core runs under our SYSTEM/session-0
+	// service, so proxy nodes never resolve ("couldn't find ip") and only DIRECT
+	// works — proven on a real user machine. stack=gvisor is the reliable
+	// userspace stack and our default; system/mixed can stall on wintun under UDP
+	// load. Extra keys the subscription adds (route-exclude-address, mtu, device)
+	// are preserved. Users can still override any of these via Settings → TUN
+	// (applyUserTunOverlay runs after this and wins).
+	rawTun["stack"] = "gvisor"
+	rawTun["auto-route"] = true
+	rawTun["auto-detect-interface"] = true
 	rawTun["strict-route"] = false
+	rawTun["dns-hijack"] = []string{"any:53"}
+	rawTun["enable"] = enableTun
 	m["tun"] = rawTun
 }
 

--- a/apps/sloth-clash-desktop/subscription_overlay.go
+++ b/apps/sloth-clash-desktop/subscription_overlay.go
@@ -151,6 +151,18 @@ func ensureTunOverlayForTraffic(m map[string]any, enableTun bool) {
 	}
 
 	rawTun["enable"] = enableTun
+	// Force strict-route OFF, overriding whatever the subscription shipped. This
+	// matches clash-verge-rev, whose base tun template overwrites the
+	// subscription's tun fields (its default strict-route is false). A
+	// subscription with strict-route: true breaks ALL proxied traffic when the
+	// core runs under our SYSTEM / session-0 service: strict-route forces the
+	// core's OWN outbound (upstream DNS + proxy-node dials) back through the TUN,
+	// so proxy nodes never resolve ("couldn't find ip") and only DIRECT works —
+	// while verge (strict-route: false) resolves fine. Proven on a real user
+	// machine: flipping this to false fixes it. A user who really wants strict
+	// routing can still set it via Settings → TUN (applyUserTunOverlay runs after
+	// this and wins).
+	rawTun["strict-route"] = false
 	m["tun"] = rawTun
 }
 


### PR DESCRIPTION
A subscription shipping strict-route:true forced the core own upstream DNS and proxy-node dials back into the TUN when the core runs under the system service, so proxy nodes failed to resolve (couldn't find ip) while DIRECT kept working. The generated runtime config now overwrites the whole tun base (stack gvisor, auto-route, auto-detect-interface, strict-route off, dns-hijack any:53), preserving the subscription route-exclude-address/mtu/device. No subscription tun field can break egress anymore; users can still override via Settings - TUN. Locked by config_parity_test