### PR TITLE
feat(startup): respect Start-minimized pref on autostart + opt-in auto-connect on startup

### DIFF
--- a/apps/sloth-clash-desktop/frontend/src/App.tsx
+++ b/apps/sloth-clash-desktop/frontend/src/App.tsx
@@ -41,7 +41,6 @@ import {
   SetHwidEnabled,
   SetLaunchOnStartupPreference,
   SetUiLanguage,
-  StartedMinimized,
 } from './api/prefs'
 import {
   ActivateProfile,
@@ -419,13 +418,12 @@ function App() {
       } catch {
         /* ignore: registry not available (non-Windows / permission denied) */
       }
-      try {
-        const launchedHidden = await StartedMinimized()
-        if (launchedHidden || settings.startMinimized) {
-          WindowHide()
-        }
-      } catch {
-        if (settings.startMinimized) WindowHide()
+      // Honour ONLY the user's "Start minimized" preference. The autostart Run
+      // key launches the app with --minimized, but that flag must NOT override
+      // the setting — it used to force the window to the tray on every boot even
+      // when "Start minimized" was off, so the app ran headless.
+      if (settings.startMinimized) {
+        WindowHide()
       }
       try {
         const prefs = await GetDesktopPrefs()
@@ -1515,6 +1513,25 @@ function App() {
     }
     await refresh()
   }
+
+  // Auto-connect on startup (opt-in). Once, when enabled and an active profile
+  // exists and we are not already connecting/connected, bring the connection up
+  // in the last-active traffic mode. Reuses connectAction so it shares all the
+  // usual guards + error toasts.
+  const autoConnectFiredRef = useRef(false)
+  useEffect(() => {
+    if (autoConnectFiredRef.current) return
+    if (!settings.autoConnectOnStartup) return
+    if (!hasActiveProfile) return
+    const status = state?.connection?.status
+    if (status === 'connected' || status === 'connecting') return
+    autoConnectFiredRef.current = true
+    void connectAction()
+  }, [
+    settings.autoConnectOnStartup,
+    hasActiveProfile,
+    state?.connection?.status,
+  ])
 
   const refreshRuleProviderOne = useCallback(
     async (name: string) => {

--- a/apps/sloth-clash-desktop/frontend/src/locales/en.json
+++ b/apps/sloth-clash-desktop/frontend/src/locales/en.json
@@ -28,6 +28,7 @@
     "uiScale": "Interface scale",
     "startMinimized": "Start minimized",
     "launchOnStartup": "Launch on startup",
+    "autoConnectOnStartup": "Auto-connect on startup",
     "closeToTray": "Close to tray (else quit)",
     "connection": "Connection",
     "smartDns": "Smart DNS fallback",

--- a/apps/sloth-clash-desktop/frontend/src/locales/ru.json
+++ b/apps/sloth-clash-desktop/frontend/src/locales/ru.json
@@ -28,6 +28,7 @@
     "uiScale": "Масштаб интерфейса",
     "startMinimized": "Запуск свёрнутым",
     "launchOnStartup": "Автозапуск",
+    "autoConnectOnStartup": "Авто-подключение при запуске",
     "closeToTray": "Закрывать в трей (иначе выход)",
     "connection": "Подключение",
     "smartDns": "Умный DNS fallback",

--- a/apps/sloth-clash-desktop/frontend/src/locales/zh.json
+++ b/apps/sloth-clash-desktop/frontend/src/locales/zh.json
@@ -28,6 +28,7 @@
     "uiScale": "界面缩放",
     "startMinimized": "启动时最小化",
     "launchOnStartup": "开机启动",
+    "autoConnectOnStartup": "启动时自动连接",
     "closeToTray": "关闭到托盘（否则退出）",
     "connection": "连接",
     "smartDns": "智能 DNS 回退",

--- a/apps/sloth-clash-desktop/frontend/src/pages/Settings.tsx
+++ b/apps/sloth-clash-desktop/frontend/src/pages/Settings.tsx
@@ -229,6 +229,19 @@ export function SettingsPage({
               />
             </div>
             <div className="settingsToggleRow">
+              <span>{t('settings.autoConnectOnStartup')}</span>
+              <SettingsSwitch
+                checked={settings.autoConnectOnStartup}
+                label={t('settings.autoConnectOnStartup')}
+                onToggle={() =>
+                  onSetSetting(
+                    'autoConnectOnStartup',
+                    !settings.autoConnectOnStartup,
+                  )
+                }
+              />
+            </div>
+            <div className="settingsToggleRow">
               <span>{t('settings.closeToTray')}</span>
               <SettingsSwitch
                 checked={settings.closeToTray}

--- a/apps/sloth-clash-desktop/frontend/src/types/app.ts
+++ b/apps/sloth-clash-desktop/frontend/src/types/app.ts
@@ -58,6 +58,7 @@ export type ConnectionsOverview = {
 export type CompactSettings = {
   startMinimized: boolean
   launchOnStartup: boolean
+  autoConnectOnStartup: boolean
   closeToTray: boolean
   dnsSmartFallback: boolean
   dnsIpv6: boolean

--- a/apps/sloth-clash-desktop/frontend/src/utils/settings.ts
+++ b/apps/sloth-clash-desktop/frontend/src/utils/settings.ts
@@ -4,6 +4,7 @@ import type { CompactSettings } from '../types/app'
 export const DEFAULT_SETTINGS: CompactSettings = {
   startMinimized: false,
   launchOnStartup: false,
+  autoConnectOnStartup: false,
   closeToTray: true,
   dnsSmartFallback: true,
   dnsIpv6: false,


### PR DESCRIPTION
## Problem
Two startup issues on Windows:
1. **App launches headless.** Autostart writes `"<exe>" --minimized` to the HKCU
   Run key, and the frontend force-hid the window on that flag — ignoring the
   user's **"Start minimized"** preference. So on every boot the app went to the
   tray even when the setting was off, leaving it running with no visible window.
2. **No auto-connect on startup.** On launch the core is warm-booted but **idle**
   (TUN off / disconnected), so users who want to be protected right after boot
   had to open the app and click Connect.

## What changed (frontend only)
- **Window visibility now follows the `Start minimized` preference only.** The
  autostart `--minimized` flag no longer forces the window to the tray (the flag
  is left in place but is inert). Result: Start-minimized OFF → window appears on
  boot; ON → goes to tray, as expected.
- **New opt-in "Auto-connect on startup" setting** (default OFF). When enabled, a
  once-guarded startup effect brings the connection up in the **last-active
  traffic mode** (TUN/Proxy) if there's an active profile and the app isn't
  already connecting/connected. Reuses the normal connect path (guards + error
  toasts). Toggle added to Settings, localized (en/ru/zh).

## Behavior matrix
| Start minimized | Auto-connect | On boot |
| --- | --- | --- |
| off | off | window shows, core warm-boots idle (current default) |
| on  | off | tray, idle |
| off | on  | window shows, connects in last mode |
| on  | on  | tray, connects in last mode (silent) |

## Notes
- Frontend-only: no Go / no Wails-binding changes. `bootActiveProfileCoreInBackground`
  (warm-boot idle) is unchanged; the new setting is what actually connects.

## Testing
- Start-minimized OFF + autostart ON → reboot/relogin → window **appears**
  (no longer headless). Toggle Start-minimized ON → goes to tray.
- Enable "Auto-connect on startup" with an active profile → relaunch → connects
  automatically in the last mode. Disable → core warm-boots idle (disconnected).
