### PR TITLE
hardening: robustness + input-validation fixes from the internal audit

### DIFF
--- a/apps/sloth-clash-desktop/app.go
+++ b/apps/sloth-clash-desktop/app.go
@@ -118,9 +118,9 @@ func (a *App) startup(ctx context.Context) {
 	if trayRuntimeEnabled() {
 		startAppTray(a)
 	}
-	go a.startProfileAutoUpdateLoop(ctx)
-	go a.updateCheckLoop(ctx)
-	go a.runRuntimeSupervisorLoop(ctx)
+	go a.runGuardedLoop(ctx, "profile-autoupdate", a.startProfileAutoUpdateLoop)
+	go a.runGuardedLoop(ctx, "update-check", a.updateCheckLoop)
+	go a.runGuardedLoop(ctx, "supervisor", a.runRuntimeSupervisorLoop)
 	a.emitAppStateChanged()
 	// Warm the core in the background for the active profile (cold start with
 	// tun.enable: false) so the first Connect only has to push a single
@@ -745,7 +745,10 @@ func (a *App) EnsureTunReady() TunSetupResult {
 	if a.state.Service.Installed {
 		a.state.Traffic = "tun"
 		a.state.UpdatedAt = time.Now().Unix()
-		_ = a.persistProfilesLocked()
+		if err := a.persistProfilesLocked(); err != nil {
+			debugLog("profiles", "A4", "app.go", "failed to persist profiles",
+				map[string]any{"error": err.Error()})
+		}
 		return TunSetupResult{Success: true, Message: "TUN enabled", InstallAction: false}
 	}
 	return TunSetupResult{
@@ -1662,7 +1665,7 @@ func (a *App) OnWindowBecameVisible() {
 	connected := a.state.Connection.Status == "connected"
 	a.mu.RUnlock()
 	if connected {
-		go func() { _, _ = a.RefreshHomeInsight() }()
+		a.safeGo("insight", func() { _, _ = a.RefreshHomeInsight() })
 	}
 	if runtime.GOOS == "windows" {
 		a.maybeWindowsSysProxyReconcile()

--- a/apps/sloth-clash-desktop/app_connect.go
+++ b/apps/sloth-clash-desktop/app_connect.go
@@ -210,7 +210,7 @@ func (a *App) runConnectJob(active Profile, gen uint64) {
 		"gen": gen,
 	})
 	a.emitAppStateChanged()
-	go func() { _, _ = a.RefreshHomeInsight() }()
+	a.safeGo("insight", func() { _, _ = a.RefreshHomeInsight() })
 }
 
 func (a *App) finishConnectJobFailed(gen uint64, err error) {

--- a/apps/sloth-clash-desktop/frontend/src/App.css
+++ b/apps/sloth-clash-desktop/frontend/src/App.css
@@ -5218,3 +5218,46 @@
   color: var(--text);
   background: rgba(255, 255, 255, 0.06);
 }
+
+/* Top-level ErrorBoundary fallback (last-resort UI when a render throws). */
+.appErrorFallback {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  gap: 12px;
+  height: 100vh;
+  padding: 32px;
+  text-align: center;
+}
+.appErrorIcon {
+  font-size: 2.4rem;
+}
+.appErrorTitle {
+  margin: 0;
+  font-size: 1.3rem;
+}
+.appErrorLead {
+  margin: 0;
+  max-width: 420px;
+  color: var(--muted);
+  font-size: 0.92rem;
+}
+.appErrorDetail {
+  max-width: 520px;
+  max-height: 160px;
+  overflow: auto;
+  padding: 10px 14px;
+  border: 1px solid var(--line);
+  border-radius: var(--radius-sm);
+  background: var(--panel-2);
+  font-size: 0.8rem;
+  white-space: pre-wrap;
+  word-break: break-word;
+  text-align: left;
+}
+.appErrorActions {
+  display: flex;
+  gap: 10px;
+  margin-top: 6px;
+}

--- a/apps/sloth-clash-desktop/frontend/src/components/AppErrorFallback.tsx
+++ b/apps/sloth-clash-desktop/frontend/src/components/AppErrorFallback.tsx
@@ -1,0 +1,39 @@
+// Last-resort UI shown by the top-level ErrorBoundary when a render throws.
+// Deliberately dependency-free (plain strings, no i18n/hooks) — it must render
+// even if the thing that broke is a provider/translation. The backend + tunnel
+// keep running (only the WebView UI process is affected), so a reload recovers.
+import type { FallbackProps } from 'react-error-boundary'
+
+export function AppErrorFallback({ error, resetErrorBoundary }: FallbackProps) {
+  const message =
+    error instanceof Error ? error.message : String(error ?? 'Unknown error')
+  return (
+    <div className="appErrorFallback" role="alert">
+      <div className="appErrorIcon" aria-hidden>
+        ⚠️
+      </div>
+      <h2 className="appErrorTitle">Something went wrong</h2>
+      <p className="appErrorLead">
+        The interface hit an unexpected error. Your connection is unaffected —
+        reload the window to recover.
+      </p>
+      <pre className="appErrorDetail">{message}</pre>
+      <div className="appErrorActions">
+        <button
+          type="button"
+          className="btn primary"
+          onClick={resetErrorBoundary}
+        >
+          Try again
+        </button>
+        <button
+          type="button"
+          className="btn ghost"
+          onClick={() => window.location.reload()}
+        >
+          Reload window
+        </button>
+      </div>
+    </div>
+  )
+}

--- a/apps/sloth-clash-desktop/frontend/src/hooks/queries/useAdvancedInfo.ts
+++ b/apps/sloth-clash-desktop/frontend/src/hooks/queries/useAdvancedInfo.ts
@@ -1,29 +1,25 @@
 import { useQuery } from '@tanstack/react-query'
+import { useCallback } from 'react'
 
 import { GetAdvancedGeoStatus, GetAdvancedPaths } from '../../api/diagnostics'
 import type { main } from '../../api/models'
 
-/** Paths + geo-data status for the Advanced screen. Polled lazily so a
- *  re-extract / restart-core action surfaces a fresh size/mtime without the
- *  user having to navigate away. */
+/** Paths + geo-data status (Advanced screen). `refresh` memoized (audit C1-1). */
 export function useAdvancedInfo(enabled: boolean) {
-  const paths = useQuery({
+  const { data: pathsData, refetch: refetchPaths } = useQuery({
     queryKey: ['advanced-paths'],
     queryFn: () => GetAdvancedPaths() as Promise<main.AdvancedPaths>,
     enabled,
   })
-  const geo = useQuery({
+  const { data: geoData, refetch: refetchGeo } = useQuery({
     queryKey: ['advanced-geo'],
     queryFn: () => GetAdvancedGeoStatus() as Promise<main.AdvancedGeoStatus>,
     enabled,
     refetchInterval: enabled ? 8_000 : false,
   })
-  return {
-    paths: paths.data ?? null,
-    geo: geo.data ?? null,
-    refresh: () => {
-      void paths.refetch()
-      void geo.refetch()
-    },
-  }
+  const refresh = useCallback(() => {
+    void refetchPaths()
+    void refetchGeo()
+  }, [refetchPaths, refetchGeo])
+  return { paths: pathsData ?? null, geo: geoData ?? null, refresh }
 }

--- a/apps/sloth-clash-desktop/frontend/src/hooks/queries/useConnectionsOverview.ts
+++ b/apps/sloth-clash-desktop/frontend/src/hooks/queries/useConnectionsOverview.ts
@@ -1,4 +1,5 @@
 import { useQuery, useQueryClient } from '@tanstack/react-query'
+import { useCallback } from 'react'
 
 import {
   CloseAllConnections,
@@ -7,26 +8,22 @@ import {
 import type { ConnectionsOverview } from '../../types/app'
 
 /**
- * Connections snapshot poll — auto-refetches every 3.5s while `enabled`,
- * mirroring the prior `setInterval` loop in App.tsx that ran whenever the
- * Connections screen was visible.
+ * Connections snapshot poll — auto-refetches every 3.5s while `enabled`.
+ * `refresh`/`closeAll` are memoized: a fresh identity each render is the footgun
+ * that caused the useUpdateState render-loop (audit C1-1).
  */
 export function useConnectionsOverview(enabled: boolean) {
   const qc = useQueryClient()
-  const q = useQuery({
+  const { data, isFetching, refetch } = useQuery({
     queryKey: ['connections-overview'],
     queryFn: () => FetchConnectionsOverview() as Promise<ConnectionsOverview>,
     enabled,
     refetchInterval: enabled ? 3500 : false,
   })
-  const closeAll = async () => {
+  const refresh = useCallback(() => void refetch(), [refetch])
+  const closeAll = useCallback(async () => {
     await CloseAllConnections()
     void qc.invalidateQueries({ queryKey: ['connections-overview'] })
-  }
-  return {
-    overview: q.data ?? null,
-    busy: q.isFetching,
-    refresh: () => void q.refetch(),
-    closeAll,
-  }
+  }, [qc])
+  return { overview: data ?? null, busy: isFetching, refresh, closeAll }
 }

--- a/apps/sloth-clash-desktop/frontend/src/hooks/queries/useRulesOverview.ts
+++ b/apps/sloth-clash-desktop/frontend/src/hooks/queries/useRulesOverview.ts
@@ -1,22 +1,16 @@
 import { useQuery } from '@tanstack/react-query'
+import { useCallback } from 'react'
 
 import type { main } from '../../api/models'
 import { FetchRulesOverview } from '../../api/rules'
 
-/**
- * Mihomo rules snapshot. Only fetches when `enabled` (Rules screen is open).
- * Manual refresh via the returned `refresh()` (used by the bulk
- * "Update all providers" button after it cycles through the providers).
- */
+/** Mihomo rules snapshot (Rules screen). `refresh` memoized (audit C1-1). */
 export function useRulesOverview(enabled: boolean) {
-  const q = useQuery({
+  const { data, isFetching, refetch } = useQuery({
     queryKey: ['rules-overview'],
     queryFn: () => FetchRulesOverview() as Promise<main.RulesOverview>,
     enabled,
   })
-  return {
-    overview: q.data ?? null,
-    busy: q.isFetching,
-    refresh: () => void q.refetch(),
-  }
+  const refresh = useCallback(() => void refetch(), [refetch])
+  return { overview: data ?? null, busy: isFetching, refresh }
 }

--- a/apps/sloth-clash-desktop/frontend/src/hooks/queries/useRuntimeDiag.ts
+++ b/apps/sloth-clash-desktop/frontend/src/hooks/queries/useRuntimeDiag.ts
@@ -1,18 +1,14 @@
 import { useQuery } from '@tanstack/react-query'
+import { useCallback } from 'react'
 
 import { GetRuntimeDiagEvents } from '../../api/diagnostics'
 import type { main } from '../../api/models'
 
 const REFETCH_INTERVAL = 3_000
 
-/**
- * Runtime trace ring (Advanced screen). Polls while the Advanced screen is
- * visible so the user sees fresh events without manual refresh, but stays
- * idle everywhere else — the ring is bounded server-side, dropping events on
- * write is fine.
- */
+/** Runtime trace ring (Advanced screen). `refresh` memoized (audit C1-1). */
 export function useRuntimeDiag(enabled: boolean) {
-  const q = useQuery({
+  const { data, isFetching, refetch } = useQuery({
     queryKey: ['runtime-diag'],
     queryFn: () =>
       GetRuntimeDiagEvents() as Promise<main.RuntimeDiagEvent[] | null>,
@@ -20,9 +16,10 @@ export function useRuntimeDiag(enabled: boolean) {
     refetchInterval: enabled ? REFETCH_INTERVAL : false,
     refetchIntervalInBackground: false,
   })
+  const refresh = useCallback(() => void refetch(), [refetch])
   return {
-    events: (q.data ?? []) as main.RuntimeDiagEvent[],
-    busy: q.isFetching,
-    refresh: () => void q.refetch(),
+    events: (data ?? []) as main.RuntimeDiagEvent[],
+    busy: isFetching,
+    refresh,
   }
 }

--- a/apps/sloth-clash-desktop/frontend/src/hooks/queries/useServiceLog.ts
+++ b/apps/sloth-clash-desktop/frontend/src/hooks/queries/useServiceLog.ts
@@ -1,21 +1,19 @@
 import { useQuery } from '@tanstack/react-query'
+import { useCallback } from 'react'
 
 import { ReadServiceLatestLog } from '../../api/diagnostics'
 import type { main } from '../../api/models'
 
 const TAIL_BYTES = 200_000
 
-/** Last 200 KB of the privileged service log (Logs screen). */
+/** Last 200 KB of the privileged service log. `refresh` memoized (audit C1-1). */
 export function useServiceLog(enabled: boolean) {
-  const q = useQuery({
+  const { data, isFetching, refetch } = useQuery({
     queryKey: ['service-log'],
     queryFn: () =>
       ReadServiceLatestLog(TAIL_BYTES) as Promise<main.ServiceLogPeek>,
     enabled,
   })
-  return {
-    log: q.data ?? null,
-    busy: q.isFetching,
-    refresh: () => void q.refetch(),
-  }
+  const refresh = useCallback(() => void refetch(), [refetch])
+  return { log: data ?? null, busy: isFetching, refresh }
 }

--- a/apps/sloth-clash-desktop/frontend/src/main.tsx
+++ b/apps/sloth-clash-desktop/frontend/src/main.tsx
@@ -1,13 +1,25 @@
 import { QueryClientProvider } from '@tanstack/react-query'
 import React from 'react'
 import { createRoot } from 'react-dom/client'
+import { ErrorBoundary } from 'react-error-boundary'
 import { I18nextProvider } from 'react-i18next'
 
 import './style.css'
 import App from './App'
+import { AppErrorFallback } from './components/AppErrorFallback'
 import i18n from './i18n'
 import { queryClient } from './queryClient'
 import { applyUiScale, loadCompactSettings } from './utils/settings'
+
+// Global safety net: surface (don't silently swallow) unhandled promise
+// rejections and uncaught errors. They no longer vanish into the void — at
+// minimum they hit the console for post-mortem, and never crash the app.
+window.addEventListener('unhandledrejection', (e) => {
+  console.error('[unhandledrejection]', e.reason)
+})
+window.addEventListener('error', (e) => {
+  console.error('[uncaught error]', e.error ?? e.message)
+})
 
 // Apply the persisted UI zoom before first paint so there's no resize flash.
 applyUiScale(loadCompactSettings().uiScale)
@@ -20,7 +32,9 @@ root.render(
   <React.StrictMode>
     <QueryClientProvider client={queryClient}>
       <I18nextProvider i18n={i18n}>
-        <App />
+        <ErrorBoundary FallbackComponent={AppErrorFallback}>
+          <App />
+        </ErrorBoundary>
       </I18nextProvider>
     </QueryClientProvider>
   </React.StrictMode>,

--- a/apps/sloth-clash-desktop/merge_template.go
+++ b/apps/sloth-clash-desktop/merge_template.go
@@ -87,7 +87,9 @@ func mergeListPrepend(doc map[string]any, key string, patch any) {
 		return
 	}
 	base := listGet(doc, key)
-	doc[key] = append(add, base...)
+	// Copy first so we never mutate the template's slice in place (append can
+	// alias the source backing array if it has spare capacity).
+	doc[key] = append(append([]any{}, add...), base...)
 }
 
 func mergeListAppend(doc map[string]any, key string, patch any) {
@@ -99,7 +101,7 @@ func mergeListAppend(doc map[string]any, key string, patch any) {
 		return
 	}
 	base := listGet(doc, key)
-	doc[key] = append(base, add...)
+	doc[key] = append(append([]any{}, base...), add...)
 }
 
 func listGet(doc map[string]any, key string) []any {

--- a/apps/sloth-clash-desktop/profile_config_api.go
+++ b/apps/sloth-clash-desktop/profile_config_api.go
@@ -16,7 +16,7 @@ import (
 func (a *App) GetProfilePaths(profileID string) ProfilePaths {
 	profileID = strings.TrimSpace(profileID)
 	out := ProfilePaths{}
-	if profileID == "" {
+	if !validProfileID(profileID) {
 		return out
 	}
 	root, err := slothDataRoot()
@@ -41,7 +41,7 @@ func (a *App) GetProfilePaths(profileID string) ProfilePaths {
 // subscription rules UX.
 func (a *App) GetProfileRulesBaseline(profileID string) ProfileRulesBaseline {
 	profileID = strings.TrimSpace(profileID)
-	if profileID == "" {
+	if !validProfileID(profileID) {
 		return ProfileRulesBaseline{LastError: "profile id is required"}
 	}
 	a.mu.RLock()
@@ -116,7 +116,7 @@ func (a *App) GetProfileRulesBaseline(profileID string) ProfileRulesBaseline {
 // template) without editing them in place.
 func (a *App) GetProfileProxyGroupsBaseline(profileID string) ProfileProxyGroupsBaseline {
 	profileID = strings.TrimSpace(profileID)
-	if profileID == "" {
+	if !validProfileID(profileID) {
 		return ProfileProxyGroupsBaseline{LastError: "profile id is required"}
 	}
 	a.mu.RLock()
@@ -192,7 +192,7 @@ func (a *App) GetProfileProxyGroupsBaseline(profileID string) ProfileProxyGroups
 // ReadProfileConfig reads runtime/<id>/config.yaml when it exists.
 func (a *App) ReadProfileConfig(profileID string) ProfileConfigPeek {
 	profileID = strings.TrimSpace(profileID)
-	if profileID == "" {
+	if !validProfileID(profileID) {
 		return ProfileConfigPeek{LastError: "profile id is required"}
 	}
 	p := a.GetProfilePaths(profileID).ConfigPath
@@ -266,7 +266,7 @@ func (a *App) ensureProfileConfigSnapshot(profileID string) error {
 // WriteProfileConfig replaces config.yaml for a profile (must be valid YAML mapping).
 func (a *App) WriteProfileConfig(profileID string, content string) (AppState, error) {
 	profileID = strings.TrimSpace(profileID)
-	if profileID == "" {
+	if !validProfileID(profileID) {
 		return a.GetAppState(), errors.New("profile id is required")
 	}
 	content = strings.TrimSpace(content)
@@ -341,7 +341,15 @@ func (a *App) reconnectActiveProfile() {
 		defer a.reconnectInFlight.Store(false)
 		passes := 0
 		overall := time.Now()
+		// Safety cap: never let a self-feeding trigger turn this into an
+		// infinite core-reload livelock (bounded passes + wall budget).
+		const maxReconnectPasses = 6
+		const reconnectBudget = 30 * time.Second
 		for {
+			if passes >= maxReconnectPasses || time.Since(overall) > reconnectBudget {
+				a.traceEvent("pipeline.reconnect.capped", "stop", time.Since(overall), map[string]any{"passes": passes})
+				return
+			}
 			passes++
 			a.reconnectQueued.Store(false)
 			passStart := time.Now()

--- a/apps/sloth-clash-desktop/profile_id_guard.go
+++ b/apps/sloth-clash-desktop/profile_id_guard.go
@@ -1,0 +1,14 @@
+package main
+
+import "regexp"
+
+// profileIDPattern matches a well-formed, server-minted profile id
+// (`profile-<timestamp>`, see app.go where ids are created). Frontend-supplied
+// ids that reach filesystem paths (runtime/<id>/…) MUST match this so a crafted
+// id such as "../../x" can never traverse out of the runtime dir (audit A6-1).
+var profileIDPattern = regexp.MustCompile(`^profile-[0-9]+$`)
+
+// validProfileID reports whether id is a safe, well-formed profile id.
+func validProfileID(id string) bool {
+	return profileIDPattern.MatchString(id)
+}

--- a/apps/sloth-clash-desktop/runtime_supervisor.go
+++ b/apps/sloth-clash-desktop/runtime_supervisor.go
@@ -20,9 +20,9 @@ const coreHealthFailThreshold = 2
 type coreHealthAction int
 
 const (
-	coreHealthNoop     coreHealthAction = iota // healthy, or not monitoring
-	coreHealthCountFail                        // probe failed but still under threshold
-	coreHealthRestart                          // N consecutive fails — recover
+	coreHealthNoop      coreHealthAction = iota // healthy, or not monitoring
+	coreHealthCountFail                         // probe failed but still under threshold
+	coreHealthRestart                           // N consecutive fails — recover
 )
 
 // decideCoreHealth is the pure decision for the health watchdog: given whether
@@ -180,7 +180,7 @@ func (a *App) runNetworkResumePass(restartInProgress *atomic.Bool) {
 		}()
 		return
 	}
-	go func() { _, _ = a.RefreshHomeInsight() }()
+	a.safeGo("insight", func() { _, _ = a.RefreshHomeInsight() })
 	if runtime.GOOS == "windows" && traffic == "proxy" {
 		a.maybeWindowsSysProxyReconcile()
 	}

--- a/apps/sloth-clash-desktop/safe_goroutine.go
+++ b/apps/sloth-clash-desktop/safe_goroutine.go
@@ -1,0 +1,54 @@
+package main
+
+import (
+	"context"
+	"fmt"
+	"runtime/debug"
+	"time"
+)
+
+// A panic in ANY goroutine terminates the whole process (Go semantics). For a
+// tray-resident VPN client that means "the app vanished and the tunnel dropped"
+// with no log. The helpers here contain background panics: they log (name +
+// stack) and keep the app alive instead of crashing it (audit G1).
+
+// safeGo runs fn in a new goroutine with panic recovery. Use for one-off
+// background work (insight refresh, subscription refresh, event handlers).
+func (a *App) safeGo(name string, fn func()) {
+	go func() {
+		defer recoverGoroutine(name)
+		fn()
+	}()
+}
+
+// runGuardedLoop runs a long-lived loop (supervisor, update-check,
+// auto-update) with panic recovery AND auto-restart: a panic in one iteration
+// is logged and the loop is restarted (after a short pause) so the self-healing
+// machinery survives a transient hiccup instead of dying silently. Exits only
+// when ctx is cancelled.
+func (a *App) runGuardedLoop(ctx context.Context, name string, loop func(context.Context)) {
+	for {
+		func() {
+			defer recoverGoroutine(name)
+			loop(ctx) // normally blocks until ctx.Done()
+		}()
+		select {
+		case <-ctx.Done():
+			return
+		default:
+			// loop returned early (panic or unexpected) — pause, then restart.
+			time.Sleep(1 * time.Second)
+		}
+	}
+}
+
+// recoverGoroutine is the shared deferred recover body.
+func recoverGoroutine(name string) {
+	if r := recover(); r != nil {
+		debugLog("panic", "G1", name, "recovered background goroutine panic",
+			map[string]any{
+				"panic": fmt.Sprintf("%v", r),
+				"stack": string(debug.Stack()),
+			})
+	}
+}

--- a/apps/sloth-clash-desktop/safe_goroutine_test.go
+++ b/apps/sloth-clash-desktop/safe_goroutine_test.go
@@ -1,0 +1,18 @@
+package main
+
+import (
+	"sync"
+	"testing"
+)
+
+// A panic inside safeGo must be contained (recovered), not propagate/crash.
+func TestSafeGoRecoversPanic(t *testing.T) {
+	a := &App{}
+	var wg sync.WaitGroup
+	wg.Add(1)
+	a.safeGo("test", func() {
+		defer wg.Done()
+		panic("boom")
+	})
+	wg.Wait() // if the panic weren't recovered, the test process would crash
+}

--- a/apps/sloth-clash-desktop/tun_settings.go
+++ b/apps/sloth-clash-desktop/tun_settings.go
@@ -180,6 +180,17 @@ func normalizeFindProcessMode(v string) string {
 }
 
 // GetDesktopPrefs is the Wails-exposed getter for the Settings UI.
+
+// savePrefsBestEffort persists desktop prefs and logs on failure instead of
+// silently dropping the error (audit A4-1) — a full disk / ACL issue is at
+// least visible in the debug log.
+func savePrefsBestEffort(snapshot DesktopPrefs) {
+	if err := saveDesktopPrefsLocked(snapshot); err != nil {
+		debugLog("prefs", "A4", "tun_settings.go", "failed to persist desktop prefs",
+			map[string]any{"error": err.Error()})
+	}
+}
+
 func (a *App) GetDesktopPrefs() DesktopPrefs {
 	_ = a
 	return currentDesktopPrefs()
@@ -201,7 +212,7 @@ func (a *App) SetTunSettings(next TunSettings) DesktopPrefs {
 	prefsMu.Lock()
 	prefsCurrent.TUN = next
 	snapshot := prefsCurrent
-	_ = saveDesktopPrefsLocked(snapshot)
+	savePrefsBestEffort(snapshot)
 	prefsMu.Unlock()
 
 	a.triggerRuntimeReloadForPrefs()
@@ -221,7 +232,7 @@ func (a *App) SetUiLanguage(lang string) DesktopPrefs {
 	prefsMu.Lock()
 	prefsCurrent.Lang = lang
 	snapshot := prefsCurrent
-	_ = saveDesktopPrefsLocked(snapshot)
+	savePrefsBestEffort(snapshot)
 	prefsMu.Unlock()
 	return snapshot
 }
@@ -236,7 +247,7 @@ func (a *App) SetHwidEnabled(enabled bool) DesktopPrefs {
 	prefsMu.Lock()
 	prefsCurrent.Privacy.HwidEnabled = &v
 	snapshot := prefsCurrent
-	_ = saveDesktopPrefsLocked(snapshot)
+	savePrefsBestEffort(snapshot)
 	prefsMu.Unlock()
 	return snapshot
 }
@@ -250,7 +261,7 @@ func (a *App) SetAppAutoUpdateEnabled(enabled bool) DesktopPrefs {
 	prefsMu.Lock()
 	prefsCurrent.AppUpdate.AutoCheckEnabled = &v
 	snapshot := prefsCurrent
-	_ = saveDesktopPrefsLocked(snapshot)
+	savePrefsBestEffort(snapshot)
 	prefsMu.Unlock()
 	return snapshot
 }
@@ -262,7 +273,7 @@ func (a *App) SetTrafficSettings(next TrafficSettings) DesktopPrefs {
 	prefsMu.Lock()
 	prefsCurrent.Traffic = next
 	snapshot := prefsCurrent
-	_ = saveDesktopPrefsLocked(snapshot)
+	savePrefsBestEffort(snapshot)
 	prefsMu.Unlock()
 
 	a.triggerRuntimeReloadForPrefs()


### PR DESCRIPTION
## Summary
Seven low-risk hardening fixes surfaced by a full internal audit of the desktop app.
All are defense-in-depth / robustness improvements — **no active user-facing bug**,
none change normal behaviour. Grouped into 5 atomic commits (some share a file).

## Changes
- **Render-loop prevention (C1-1).** Five react-query hooks
  (`useConnectionsOverview`, `useRulesOverview`, `useRuntimeDiag`, `useServiceLog`,
  `useAdvancedInfo`) now memoize their returned `refresh`/`closeAll` (`useCallback`
  over the stable `refetch`). An unstable callback identity used as an effect
  dependency is the exact footgun behind the earlier Settings render-loop; this
  closes the whole class.
- **Top-level ErrorBoundary + global handlers (A8-1).** The app is wrapped in a
  last-resort `ErrorBoundary` (dependency-free fallback with a Reload action), and
  `unhandledrejection` / `error` are logged instead of silently swallowed. A render
  throw now yields a recoverable screen rather than a blank window; the tunnel is
  unaffected (only the WebView UI process).
- **Slice-aliasing fix in template merge (E1-1).** `mergeListPrepend`/`Append` copy
  the source slice before `append`, so a template's slice can never be mutated in
  place if it happens to carry spare capacity.
- **profileID path-traversal guard (A6-1).** Frontend-supplied `profileID` is
  validated (`^profile-[0-9]+$`) before it reaches any `filepath.Join(runtime/<id>)`
  — a crafted id can no longer traverse out of the runtime directory.
- **Reconnect coalescing loop cap (D2-1).** The hot-reload coalescing loop now has a
  safety bound (≤6 passes / 30s) so a future self-feeding trigger can't turn it into
  an infinite core-reload livelock.
- **Background-goroutine panic guard (G1).** New `safeGo` / `runGuardedLoop` helpers
  contain panics in background goroutines: the three long-lived loops (supervisor,
  update-check, auto-update) auto-restart on panic, and the insight goroutines are
  wrapped. A background panic is now logged instead of terminating the whole process.
- **Log persist/save errors (A4-1).** Previously-ignored `persistProfilesLocked` /
  `saveDesktopPrefsLocked` failures are logged (a full-disk / ACL issue is at least
  visible instead of silently losing settings).

## Testing
- Builds on **windows / darwin / linux**; full `go test` green (incl. a new
  `TestSafeGoRecoversPanic` proving a background panic is contained).
- `staticcheck` clean; `tsc --noEmit` + eslint (0 warnings); locales in parity.
- No new Wails bindings (helpers are internal).

## Scope / follow-ups
Deliberately the low-risk, easy-to-verify subset. Four heavier audit items are left
for a separate pass (resume-clock, updater temp-file hardening, CI action pinning,
traffic-mode rollback). None of these block a release.
