### PR TITLE
fix: Hysteria2 connectivity & false-504 fixes

### DIFF
--- a/apps/sloth-clash-desktop/core_manager.go
+++ b/apps/sloth-clash-desktop/core_manager.go
@@ -598,7 +598,7 @@ func (a *App) writeRuntimeConfig(dataDir string, subURL string, ageKey string, e
 	fmt.Fprintf(&cfg, "    path: ./providers/sub1.yaml\n")
 	fmt.Fprintf(&cfg, "    health-check:\n")
 	fmt.Fprintf(&cfg, "      enable: true\n")
-	fmt.Fprintf(&cfg, "      url: http://www.gstatic.com/generate_204\n")
+	fmt.Fprintf(&cfg, "      url: http://cp.cloudflare.com/generate_204\n")
 	fmt.Fprintf(&cfg, "      interval: 600\n\n")
 
 	// Bare fallback groups: emit a `select` group (Manual) that lists Auto
@@ -614,7 +614,7 @@ func (a *App) writeRuntimeConfig(dataDir string, subURL string, ageKey string, e
 	fmt.Fprintf(&cfg, "    type: url-test\n")
 	fmt.Fprintf(&cfg, "    use:\n")
 	fmt.Fprintf(&cfg, "      - sub1\n")
-	fmt.Fprintf(&cfg, "    url: http://www.gstatic.com/generate_204\n")
+	fmt.Fprintf(&cfg, "    url: http://cp.cloudflare.com/generate_204\n")
 	fmt.Fprintf(&cfg, "    interval: 300\n")
 	fmt.Fprintf(&cfg, "    tolerance: 50\n")
 	fmt.Fprintf(&cfg, "  - name: Manual\n")

--- a/apps/sloth-clash-desktop/home_insight.go
+++ b/apps/sloth-clash-desktop/home_insight.go
@@ -207,13 +207,13 @@ func resolveInsightDelayName(groups []ProxyGroup, activeGroup string) string {
 }
 
 func fetchMihomoDelay(ctx context.Context, listen, secret, proxyName string) (int, error) {
-	return fetchMihomoDelayToURL(ctx, listen, secret, proxyName, "http://www.gstatic.com/generate_204")
+	return fetchMihomoDelayToURL(ctx, listen, secret, proxyName, "http://cp.cloudflare.com/generate_204")
 }
 
 func fetchMihomoDelayToURL(ctx context.Context, listen, secret, proxyName, testURL string) (int, error) {
 	u := "/proxies/" + url.PathEscape(proxyName) + "/delay"
 	q := url.Values{}
-	q.Set("timeout", "4000")
+	q.Set("timeout", "10000") // verge parity; QUIC/hysteria cold handshake needs headroom
 	q.Set("url", testURL)
 	u += "?" + q.Encode()
 

--- a/apps/sloth-clash-desktop/profile_config_api.go
+++ b/apps/sloth-clash-desktop/profile_config_api.go
@@ -157,7 +157,7 @@ func (a *App) GetProfileProxyGroupsBaseline(profileID string) ProfileProxyGroups
 					"name":      "Auto",
 					"type":      "url-test",
 					"use":       []any{"sub1"},
-					"url":       "http://www.gstatic.com/generate_204",
+					"url":       "http://cp.cloudflare.com/generate_204",
 					"interval":  300,
 					"tolerance": 50,
 				},

--- a/apps/sloth-clash-desktop/proxy_delay_api.go
+++ b/apps/sloth-clash-desktop/proxy_delay_api.go
@@ -41,8 +41,13 @@ func (a *App) TestProxyDelay(name string) (int, error) {
 	}
 
 	q := url.Values{}
-	q.Set("timeout", "4000")
-	q.Set("url", "http://www.gstatic.com/generate_204")
+	// 10s (verge parity: default_latency_timeout=10000). A hysteria2/QUIC node's
+	// first probe is a cold handshake (QUIC + obfs + masquerade + uTLS) that
+	// routinely needs 4-8s over a long path — a 4s cap made working nodes show a
+	// false 504. Cloudflare's generate_204 (verge default) is a more reliable exit
+	// probe than gstatic, which some proxy exits throttle.
+	q.Set("timeout", "10000")
+	q.Set("url", "http://cp.cloudflare.com/generate_204")
 	path := "/proxies/" + url.PathEscape(name) + "/delay?" + q.Encode()
 
 	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)

--- a/apps/sloth-clash-desktop/sharelink/sharelink.go
+++ b/apps/sloth-clash-desktop/sharelink/sharelink.go
@@ -337,7 +337,7 @@ func parseTrojan(link string) (Proxy, error) {
 	if sni := firstNonEmpty(q.Get("sni"), q.Get("peer")); sni != "" {
 		p["sni"] = sni
 	}
-	if q.Get("allowInsecure") == "1" || q.Get("insecure") == "1" {
+	if insecureRequested(q) {
 		p["skip-cert-verify"] = true
 	}
 	if alpn := q.Get("alpn"); alpn != "" {
@@ -349,6 +349,21 @@ func parseTrojan(link string) (Proxy, error) {
 		applyTransport(p, network, q)
 	}
 	return p, nil
+}
+
+// insecureRequested reports whether a share link asks to skip TLS cert
+// verification. Links in the wild spell it several ways — insecure /
+// allowInsecure / allow_insecure — with values 1/true/yes. Missing any of these
+// leaves skip-cert-verify unset, which for an IP-addressed server (no IP SAN in
+// the cert) fails the handshake with "cannot validate certificate ... IP SANs".
+func insecureRequested(q url.Values) bool {
+	for _, k := range []string{"insecure", "allowInsecure", "allow_insecure"} {
+		switch strings.ToLower(strings.TrimSpace(q.Get(k))) {
+		case "1", "true", "yes", "on":
+			return true
+		}
+	}
+	return false
 }
 
 func parseHysteria2(link string) (Proxy, error) {
@@ -379,7 +394,7 @@ func parseHysteria2(link string) (Proxy, error) {
 	if sni := q.Get("sni"); sni != "" {
 		p["sni"] = sni
 	}
-	if q.Get("insecure") == "1" {
+	if insecureRequested(q) {
 		p["skip-cert-verify"] = true
 	}
 	if obfs := q.Get("obfs"); obfs != "" {
@@ -429,7 +444,7 @@ func parseTuic(link string) (Proxy, error) {
 	if rm := q.Get("udp_relay_mode"); rm != "" {
 		p["udp-relay-mode"] = rm
 	}
-	if q.Get("allow_insecure") == "1" {
+	if insecureRequested(q) {
 		p["skip-cert-verify"] = true
 	}
 	return p, nil

--- a/apps/sloth-clash-desktop/sharelink/sharelink_test.go
+++ b/apps/sloth-clash-desktop/sharelink/sharelink_test.go
@@ -135,6 +135,20 @@ func TestParseHysteria2(t *testing.T) {
 	}
 }
 
+func TestParseHysteria2InsecureVariants(t *testing.T) {
+	// insecure spelled as "true" (not just "1") must still set skip-cert-verify —
+	// otherwise an IP-addressed server (cert has no IP SAN) fails the handshake.
+	for _, q := range []string{"insecure=true", "insecure=1", "allowInsecure=yes"} {
+		p, err := ParseLink("hysteria2://pass@108.61.209.112:443?" + q + "#H")
+		if err != nil {
+			t.Fatalf("%s err: %v", q, err)
+		}
+		if p["skip-cert-verify"] != true {
+			t.Fatalf("%s: skip-cert-verify not set: %#v", q, p)
+		}
+	}
+}
+
 func TestParseTuic(t *testing.T) {
 	link := "tuic://uuid-1:password-1@example.com:443?sni=example.com&congestion_control=bbr&udp_relay_mode=native#U"
 	p, err := ParseLink(link)

--- a/apps/sloth-clash-desktop/subscription_config_pipeline_test.go
+++ b/apps/sloth-clash-desktop/subscription_config_pipeline_test.go
@@ -51,6 +51,35 @@ func TestSubscriptionDocIsFullProfileHeuristics(t *testing.T) {
 	}
 }
 
+func TestNormalizeProxySNI(t *testing.T) {
+	m := map[string]any{
+		"proxies": []any{
+			// hysteria2 with servername, no sni -> sni copied (the panel bug we fix).
+			map[string]any{"name": "hy2", "type": "hysteria2", "server": "1.2.3.4", "servername": "hey.example.com"},
+			// tuic likewise.
+			map[string]any{"name": "tuic", "type": "tuic", "server": "1.2.3.4", "servername": "t.example.com"},
+			// existing sni must win (never overwritten).
+			map[string]any{"name": "hy2b", "type": "hysteria2", "server": "1.2.3.4", "sni": "keep.example.com", "servername": "other.example.com"},
+			// vless uses servername natively -> must NOT get an sni injected.
+			map[string]any{"name": "vless", "type": "vless", "server": "1.2.3.4", "servername": "google.com"},
+		},
+	}
+	normalizeProxySNI(m)
+	got := m["proxies"].([]any)
+	if sni, _ := got[0].(map[string]any)["sni"].(string); sni != "hey.example.com" {
+		t.Fatalf("hy2 sni = %q, want hey.example.com", sni)
+	}
+	if sni, _ := got[1].(map[string]any)["sni"].(string); sni != "t.example.com" {
+		t.Fatalf("tuic sni = %q, want t.example.com", sni)
+	}
+	if sni, _ := got[2].(map[string]any)["sni"].(string); sni != "keep.example.com" {
+		t.Fatalf("existing sni overwritten: %q", sni)
+	}
+	if _, has := got[3].(map[string]any)["sni"]; has {
+		t.Fatalf("vless must not get sni injected")
+	}
+}
+
 func TestNormalizeProxyGroupRefsPrunesUnknownProxies(t *testing.T) {
 	t.Parallel()
 	m := map[string]any{

--- a/apps/sloth-clash-desktop/subscription_normalize.go
+++ b/apps/sloth-clash-desktop/subscription_normalize.go
@@ -395,6 +395,43 @@ func pruneFallbackAutoManualIfCustom(m map[string]any) {
 	m["proxy-groups"] = filtered
 }
 
+// tlsSNIProtocols are proxy types whose TLS server name is the `sni` field in
+// mihomo — NOT `servername` (that's vmess/vless/trojan/reality). Some panels
+// (Marzban / PasarGuard family) emit `servername` for these; mihomo ignores it,
+// so an IP-addressed server gets its cert verified against the IP and fails
+// ("cannot validate certificate ... doesn't contain any IP SANs") even though a
+// valid domain cert exists.
+var tlsSNIProtocols = map[string]bool{"hysteria2": true, "hysteria": true, "tuic": true}
+
+// normalizeProxySNI copies a stray `servername` onto `sni` for hysteria/hysteria2/
+// tuic nodes that lack an explicit sni, so a domain cert verifies against its
+// domain instead of the raw IP. Upstream (clash-verge-rev) does NOT do this, so
+// we work on subscriptions where it fails. Non-destructive: an existing sni wins,
+// and `servername` is left untouched (mihomo ignores it), so working nodes never
+// change.
+func normalizeProxySNI(m map[string]any) {
+	proxies, ok := m["proxies"].([]any)
+	if !ok {
+		return
+	}
+	for _, it := range proxies {
+		p, ok := it.(map[string]any)
+		if !ok {
+			continue
+		}
+		typ, _ := p["type"].(string)
+		if !tlsSNIProtocols[strings.ToLower(strings.TrimSpace(typ))] {
+			continue
+		}
+		if sni, _ := p["sni"].(string); strings.TrimSpace(sni) != "" {
+			continue
+		}
+		if sn, _ := p["servername"].(string); strings.TrimSpace(sn) != "" {
+			p["sni"] = sn
+		}
+	}
+}
+
 // normalizeRulesMatchLast ensures terminal MATCH rules are placed last.
 // If MATCH appears earlier, appended user rules become unreachable.
 func normalizeRulesMatchLast(m map[string]any) {

--- a/apps/sloth-clash-desktop/subscription_validate.go
+++ b/apps/sloth-clash-desktop/subscription_validate.go
@@ -178,6 +178,7 @@ func finalizeRuntimeConfigPipeline(
 	}
 	normalizeRulesMatchLast(m)
 	normalizeProxyGroupRefs(m)
+	normalizeProxySNI(m)
 	pruneFallbackAutoManualIfCustom(m)
 	cleanupUnusedProxyProviders(m)
 	overlaySlothRuntimeOnMap(m, mixedPort, ctrlPort, secret, traffic, withExternalController, enableTun)


### PR DESCRIPTION
Three independent hysteria2/QUIC fixes found while debugging a real subscription:

- Delay probe now matches upstream (10s timeout, Cloudflare generate_204). Our 4s cap made working hysteria2 nodes show a false 504 because the first QUIC+obfs+masquerade handshake needs 4-8s over a long path.
- servername→sni normalization for hysteria2/hysteria/tuic — some panels (Marzban/PasarGuard family) emit servername, which mihomo ignores for these protocols, so an IP-addressed node fails cert verification. Non-destructive; existing sni wins.
- Share-link parsing now accepts insecure=true/yes and allowInsecure (previously only insecure=1).