### PR TITLE
Mihomo core 1.19.30 + IPv6 fake-ip pool routability guard

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -4,9 +4,21 @@
 
 ### English
 
+**🐛 Sites felt slower than they should — dead IPv6 addresses handed to apps, fixed**
+- On profiles whose TUN section excludes the private IPv6 range (`fc00::/7` — a very common default), the IPv6 addresses we handed out for every domain had no route into the tunnel. Apps still tried them first: the browser burned a full connection timeout on the IPv6 attempt of every dual-stack site before falling back to IPv4, which showed up as pages (YouTube, Google Fonts and friends) taking seconds to pull assets, with nothing in the logs. Measured: `curl -6` hung for 21 s where `curl -4` finished in 0.27 s. We now drop the IPv6 fake-address pool whenever the profile's own routing rules would leave it unreachable, so apps go straight to the working path. IPv6 itself stays enabled and still travels inside the tunnel — nothing leaks.
+
+**🐛 A broken `dns:` section in a hand-edited profile was silently swallowed**
+- If a profile's DNS section was malformed (a list where a mapping belongs, typically from a hand-edited merge template), the pre-launch check quietly replaced it with defaults instead of telling you the core had rejected it. The real error is now surfaced.
+
 - **Mihomo core updated to `v1.19.30`.** Brings a security fix in the core's Go TLS stack (CVE-2026-56862) and a TUN fix where hijacked DNS replies could be sent zero-filled or stale. New protocol coverage lands with it: ZeroTier outbound, AmneziaWG 3.0/3.1, an `ip-stack` option for WireGuard/OpenVPN/MASQUE/ZeroTier, H2C and QUICv2 sniffing, `handshake-timeout` for Hysteria2, `client-metadata` for AnyTLS and `rate-limit` for the restls listener. Config generation and the runtime pipeline were verified against the new core.
 
 ### Русский
+
+**🐛 Сайты грузились медленнее, чем должны — приложениям выдавались «мёртвые» IPv6-адреса, исправлено**
+- Если в TUN-секции профиля исключён приватный диапазон IPv6 (`fc00::/7` — очень частый дефолт), то IPv6-адреса, которые мы выдавали на каждый домен, не имели маршрута в туннель. Приложения всё равно пробовали их первыми: браузер тратил полный таймаут соединения на IPv6-попытку для каждого dual-stack сайта, прежде чем откатиться на IPv4 — отсюда «страницы (YouTube, Google Fonts и т.п.) секундами тянут ресурсы», причём в логах чисто. Замерено: `curl -6` висел 21 с там, где `curl -4` отрабатывал за 0.27 с. Теперь пул фейковых IPv6-адресов убирается, если правила маршрутизации самого профиля делают его недостижимым, и приложения сразу идут рабочим путём. Сам IPv6 остаётся включённым и по-прежнему идёт внутри туннеля — утечки нет.
+
+**🐛 Сломанная секция `dns:` в отредактированном вручную профиле молча проглатывалась**
+- Если DNS-секция профиля была битой (список там, где ожидается словарь — обычно из ручного merge-шаблона), предстартовая проверка тихо подменяла её дефолтами вместо того, чтобы показать, что ядро конфиг отвергло. Теперь настоящая ошибка доходит до пользователя.
 
 - **Ядро Mihomo обновлено до `v1.19.30`.** Приносит фикс безопасности в Go-стеке TLS внутри ядра (CVE-2026-56862) и починку TUN, где перехваченные DNS-ответы могли уходить пустыми (забитыми нулями) или устаревшими. Вместе с ним — поддержка новых протоколов: outbound ZeroTier, AmneziaWG 3.0/3.1, опция `ip-stack` для WireGuard/OpenVPN/MASQUE/ZeroTier, сниффинг H2C и QUICv2, `handshake-timeout` для Hysteria2, `client-metadata` для AnyTLS и `rate-limit` для listener restls. Генерация конфига и рантайм-пайплайн проверены на новом ядре.
 

--- a/Changelog.md
+++ b/Changelog.md
@@ -1,4 +1,16 @@
-## Sloth Clash desktop `0.9.1` — Unreleased
+## Sloth Clash desktop `0.9.2` — Unreleased
+
+> ℹ️ **You may be asked once to reinstall the helper service** after this update. The privileged service only spawns cores whose hash it has pinned, and the core changed — on Windows the installer re-pins it silently, on macOS/Linux click the banner and accept the prompt.
+
+### English
+
+- **Mihomo core updated to `v1.19.30`.** Brings a security fix in the core's Go TLS stack (CVE-2026-56862) and a TUN fix where hijacked DNS replies could be sent zero-filled or stale. New protocol coverage lands with it: ZeroTier outbound, AmneziaWG 3.0/3.1, an `ip-stack` option for WireGuard/OpenVPN/MASQUE/ZeroTier, H2C and QUICv2 sniffing, `handshake-timeout` for Hysteria2, `client-metadata` for AnyTLS and `rate-limit` for the restls listener. Config generation and the runtime pipeline were verified against the new core.
+
+### Русский
+
+- **Ядро Mihomo обновлено до `v1.19.30`.** Приносит фикс безопасности в Go-стеке TLS внутри ядра (CVE-2026-56862) и починку TUN, где перехваченные DNS-ответы могли уходить пустыми (забитыми нулями) или устаревшими. Вместе с ним — поддержка новых протоколов: outbound ZeroTier, AmneziaWG 3.0/3.1, опция `ip-stack` для WireGuard/OpenVPN/MASQUE/ZeroTier, сниффинг H2C и QUICv2, `handshake-timeout` для Hysteria2, `client-metadata` для AnyTLS и `rate-limit` для listener restls. Генерация конфига и рантайм-пайплайн проверены на новом ядре.
+
+## Sloth Clash desktop `0.9.1` — 2026-08-09
 
 ### English
 

--- a/apps/sloth-clash-desktop/config_core_protocol_passthrough_test.go
+++ b/apps/sloth-clash-desktop/config_core_protocol_passthrough_test.go
@@ -1,0 +1,199 @@
+package main
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+// TestCoreProtocolSurfacePassesThroughPipeline guards the class of bug a core
+// bump can introduce silently: a proxy type or option the pinned core supports
+// but our pipeline mangles or drops on the way to config.yaml.
+//
+// The pipeline deliberately has NO proxy-type allowlist — proxies are passed
+// through verbatim and only `hysteria2`/`hysteria`/`tuic` are touched at all
+// (normalizeProxySNI). This test locks that in with the newest protocol surface
+// we ship, including options that arrived with the core bump:
+//   - zerotier: an outbound with NO server/port at all, only `network`
+//   - wireguard: nested `ip-stack` + `amnezia-wg-option` (AmneziaWG 3.x)
+//   - hysteria2: `handshake-timeout` alongside the servername→sni normalization
+//   - anytls: `client-metadata`
+//
+// When a sidecar binary is available it also asserts the shipped core actually
+// accepts the generated config, which is what makes this a compatibility test
+// rather than a shape test.
+func TestCoreProtocolSurfacePassesThroughPipeline(t *testing.T) {
+	t.Parallel()
+	subscription := `
+mixed-port: 7890
+mode: rule
+proxies:
+  - name: zt-node
+    type: zerotier
+    network: 8056c2e21c000001
+    udp: true
+    ip-stack:
+      mode: gvisor
+      congestion-controller: bbr3
+  - name: wg-amnezia
+    type: wireguard
+    server: 10.0.0.1
+    port: 51820
+    private-key: aG9wZWZ1bGx5LWEtdmFsaWQtYmFzZTY0LWtleS0xMjM0NTY=
+    public-key: aG9wZWZ1bGx5LWEtdmFsaWQtYmFzZTY0LWtleS0xMjM0NTY=
+    ip: 10.0.0.2
+    ip-stack:
+      mode: auto
+      congestion-controller: bbr
+    amnezia-wg-option:
+      jc: 4
+      s3: 100
+      i1: "<b 0xdeadbeef>"
+      disable-cookies: true
+  - name: hy2-node
+    type: hysteria2
+    server: hy2.example.test
+    port: 443
+    password: secret-pass
+    servername: hy2.example.test
+    handshake-timeout: 12
+  - name: anytls-node
+    type: anytls
+    server: at.example.test
+    port: 8443
+    password: secret-pass
+    client-metadata: "sloth/1"
+proxy-groups:
+  - name: Main
+    type: select
+    proxies:
+      - zt-node
+      - wg-amnezia
+      - hy2-node
+      - anytls-node
+      - DIRECT
+sniffer:
+  enable: true
+  sniff:
+    HTTP:
+      ports: [80, 8080]
+    QUIC:
+      ports: [443]
+rules:
+  - MATCH,Main
+`
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		_, _ = w.Write([]byte(subscription))
+	}))
+	defer srv.Close()
+
+	dir := t.TempDir()
+	outcome, err := tryWriteMergedFullProfile(
+		dir, srv.URL, "", "", "", "", 9090, 7890, "secret", "tun", true, true,
+	)
+	if err != nil {
+		t.Fatalf("tryWriteMergedFullProfile failed: %v", err)
+	}
+	if outcome != pipelineOK {
+		t.Fatalf("expected full-profile path, got outcome=%s", outcome)
+	}
+	cfg := readYAMLMapForTest(t, filepath.Join(dir, "config.yaml"))
+
+	byName := map[string]map[string]any{}
+	proxies, _ := cfg["proxies"].([]any)
+	for _, it := range proxies {
+		if p, ok := it.(map[string]any); ok {
+			name, _ := p["name"].(string)
+			byName[name] = p
+		}
+	}
+	for _, want := range []string{"zt-node", "wg-amnezia", "hy2-node", "anytls-node"} {
+		if byName[want] == nil {
+			t.Fatalf("proxy %q was dropped by the pipeline (kept %d of 4)", want, len(byName))
+		}
+	}
+
+	// zerotier has no server/port — the pipeline must not require them, and its
+	// nested ip-stack block must survive as a map.
+	zt := byName["zt-node"]
+	if zt["network"] != "8056c2e21c000001" {
+		t.Errorf("zerotier network changed: %#v", zt["network"])
+	}
+	ztStack, ok := zt["ip-stack"].(map[string]any)
+	if !ok {
+		t.Fatalf("zerotier ip-stack mangled: %#v", zt["ip-stack"])
+	}
+	if ztStack["mode"] != "gvisor" || ztStack["congestion-controller"] != "bbr3" {
+		t.Errorf("zerotier ip-stack values changed: %#v", ztStack)
+	}
+
+	amnezia, ok := byName["wg-amnezia"]["amnezia-wg-option"].(map[string]any)
+	if !ok {
+		t.Fatalf("amnezia-wg-option mangled: %#v", byName["wg-amnezia"]["amnezia-wg-option"])
+	}
+	if amnezia["jc"] != 4 || amnezia["i1"] != "<b 0xdeadbeef>" || amnezia["disable-cookies"] != true {
+		t.Errorf("amnezia-wg-option values changed: %#v", amnezia)
+	}
+
+	// handshake-timeout must stay an integer (seconds) — a float would change
+	// the field's shape for the core.
+	hy := byName["hy2-node"]
+	if ht, ok := hy["handshake-timeout"].(int); !ok || ht != 12 {
+		t.Errorf("hysteria2 handshake-timeout changed: %#v (%T)", hy["handshake-timeout"], hy["handshake-timeout"])
+	}
+	// ...while the servername→sni normalization still applies to it.
+	if hy["sni"] != "hy2.example.test" {
+		t.Errorf("hysteria2 sni not normalized from servername: %#v", hy["sni"])
+	}
+
+	if got := byName["anytls-node"]["client-metadata"]; got != "sloth/1" {
+		t.Errorf("anytls client-metadata changed: %#v", got)
+	}
+
+	// The sniffer block is passed through verbatim. Note the core's sniffer names
+	// are only TLS/HTTP/QUIC — the H2C and QUICv2 support added in 1.19.30 lives
+	// INSIDE those sniffers and is not configurable by name, so an invented name
+	// here would be rejected by the core below.
+	sniffer, _ := cfg["sniffer"].(map[string]any)
+	if sniffer == nil {
+		t.Fatalf("sniffer block dropped")
+	}
+	sniff, _ := sniffer["sniff"].(map[string]any)
+	for _, want := range []string{"HTTP", "QUIC"} {
+		if _, ok := sniff[want]; !ok {
+			t.Errorf("sniffer %s dropped: %#v", want, sniff)
+		}
+	}
+
+	bin := testCoreBinaryForPassthrough()
+	if bin == "" {
+		t.Skip("no core binary available (set SLOTH_MIHOMO_BIN or run `pnpm run prebuild`) — skipping the real-core acceptance check")
+	}
+	if err := runConfigPreflight(bin, dir); err != nil {
+		t.Fatalf("the shipped core rejected our generated config: %v", err)
+	}
+}
+
+// testCoreBinaryForPassthrough resolves a core binary to validate against:
+// the explicit SLOTH_MIHOMO_BIN override first, otherwise the locally
+// provisioned sidecar. Returns "" when neither is present.
+func testCoreBinaryForPassthrough() string {
+	if bin := strings.TrimSpace(os.Getenv("SLOTH_MIHOMO_BIN")); bin != "" {
+		return bin
+	}
+	matches, _ := filepath.Glob(filepath.Join("build", "sidecar", "sloth-mihomo-*"))
+	for _, m := range matches {
+		// The alpha sidecar is a separate, unpinned binary — never validate against it.
+		if strings.Contains(filepath.Base(m), "-alpha-") {
+			continue
+		}
+		if abs, err := filepath.Abs(m); err == nil {
+			return abs
+		}
+		return m
+	}
+	return ""
+}

--- a/apps/sloth-clash-desktop/core_manager.go
+++ b/apps/sloth-clash-desktop/core_manager.go
@@ -877,7 +877,22 @@ func repairRuntimeConfigDNS(cfgPath string) error {
 	if len(m) == 0 {
 		return nil
 	}
+	// A `dns:` key that is not a mapping means the file is broken (usually a
+	// hand-edited merge template). Healing it here would REPLACE it with our
+	// default block and hand the core a config that parses — masking the real
+	// error instead of showing it. Leave it alone so the `-t` preflight below
+	// reports what the core actually rejects.
+	if raw, has := m["dns"]; has {
+		if _, isMap := raw.(map[string]any); !isMap && raw != nil {
+			return nil
+		}
+	}
 	ensureDefaultDNSForTun(m)
+	// The self-heal above fills dns.fake-ip-range6 unconditionally, so the guard
+	// has to run here too — this is the LAST writer of config.yaml before the
+	// core reads it, and without this it would silently undo the pipeline's
+	// decision (see dropUnroutableFakeIPRange6).
+	dropUnroutableFakeIPRange6(m)
 	out, err := marshalRuntimeYAML(m)
 	if err != nil {
 		return err

--- a/apps/sloth-clash-desktop/fakeip_v6_route_guard.go
+++ b/apps/sloth-clash-desktop/fakeip_v6_route_guard.go
@@ -1,0 +1,104 @@
+package main
+
+import (
+	"net/netip"
+	"strings"
+)
+
+// prefixesFromAny parses a YAML list (or single string) of CIDRs into prefixes,
+// skipping anything unparsable — a malformed entry in a subscription must never
+// make config generation fail.
+func prefixesFromAny(v any) []netip.Prefix {
+	var raw []string
+	switch t := v.(type) {
+	case []any:
+		for _, e := range t {
+			if s, ok := e.(string); ok {
+				raw = append(raw, s)
+			}
+		}
+	case []string:
+		raw = append(raw, t...)
+	case string:
+		raw = append(raw, t)
+	}
+	out := make([]netip.Prefix, 0, len(raw))
+	for _, s := range raw {
+		p, err := netip.ParsePrefix(strings.TrimSpace(s))
+		if err != nil {
+			continue
+		}
+		out = append(out, p.Masked())
+	}
+	return out
+}
+
+// prefixCovers reports whether outer fully contains inner (same address family).
+func prefixCovers(outer, inner netip.Prefix) bool {
+	if outer.Addr().Is4() != inner.Addr().Is4() {
+		return false
+	}
+	return outer.Bits() <= inner.Bits() && outer.Contains(inner.Addr())
+}
+
+// dropUnroutableFakeIPRange6 removes `dns.fake-ip-range6` when the TUN we are
+// about to bring up would not route that pool.
+//
+// Measured on Windows 2026-08-31 with a real subscription: its tun block ships
+// `route-exclude-address: [..., fc00::/7, ...]` (the usual list — verge honours
+// the same one). mihomo's auto-route then installs the IPv6 default split MINUS
+// the excluded ranges, so our injected ULA pool `fdfe:dcba:9876::1/64` — which
+// lives inside fc00::/7 — gets no route into the tunnel at all. Windows sends
+// those connections out of the physical interface instead, where nothing answers:
+// `curl -6 https://fonts.googleapis.com` hung for 21 s and failed while the IPv4
+// path took 0.27 s, and the core log showed the packets never reached mihomo.
+// In a browser that is a Happy-Eyeballs stall on every dual-stack site — the
+// "everything feels slower than it used to" symptom.
+//
+// A black-holed pool is strictly worse than no pool: with `fake-ip-range6` absent
+// mihomo answers AAAA with NOERROR/NODATA (verified against the shipped core), so
+// apps go straight to the working IPv4 fake address. The IPv6 leak this pool was
+// added to close (architecture/ipv6.md) stays closed either way — top-level
+// `ipv6: true` keeps the TUN's v6 routes installed, so real IPv6 destinations are
+// still captured by the tunnel.
+func dropUnroutableFakeIPRange6(m map[string]any) {
+	tun, ok := m["tun"].(map[string]any)
+	if !ok {
+		return
+	}
+	if enabled, ok := tun["enable"].(bool); !ok || !enabled {
+		return
+	}
+	// With auto-route off mihomo installs no routes and ignores the exclusion
+	// list; whoever turned it off owns the routing table.
+	if auto, ok := tun["auto-route"].(bool); ok && !auto {
+		return
+	}
+	dns, ok := m["dns"].(map[string]any)
+	if !ok {
+		return
+	}
+	raw, _ := dns["fake-ip-range6"].(string)
+	pool, err := netip.ParsePrefix(strings.TrimSpace(raw))
+	if err != nil || pool.Addr().Is4() {
+		return
+	}
+	pool = pool.Masked()
+	// An explicit tun inet6-address covering the pool makes it on-link on the
+	// tunnel itself, so it stays reachable whatever the exclusion list says.
+	for _, onLink := range prefixesFromAny(tun["inet6-address"]) {
+		if prefixCovers(onLink, pool) {
+			return
+		}
+	}
+	for _, ex := range prefixesFromAny(tun["route-exclude-address"]) {
+		if !prefixCovers(ex, pool) {
+			continue
+		}
+		delete(dns, "fake-ip-range6")
+		debugLog("config", "IPV6-2", "fakeip_v6_route_guard.go:dropUnroutableFakeIPRange6",
+			"dropped fake-ip-range6: excluded from tun routing",
+			map[string]any{"pool": strings.TrimSpace(raw), "excludedBy": ex.String()})
+		return
+	}
+}

--- a/apps/sloth-clash-desktop/fakeip_v6_route_guard_test.go
+++ b/apps/sloth-clash-desktop/fakeip_v6_route_guard_test.go
@@ -1,0 +1,165 @@
+package main
+
+import (
+	"net/netip"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"gopkg.in/yaml.v3"
+)
+
+// The fake-ip v6 pool is only useful if the TUN routes it. Real-world regression
+// (measured 2026-08-31): the subscription's own `route-exclude-address` carries
+// `fc00::/7`, which swallows our injected ULA pool `fdfe:dcba:9876::1/64`, so
+// mihomo's auto-route installs no route for it. Every AAAA answer then points at
+// an address the OS sends out of the physical interface, where it dies — a full
+// connect timeout on the IPv6 half of every dual-stack site.
+// See dropUnroutableFakeIPRange6 and architecture/ipv6.md.
+
+// profileWithTunRouteExcludes builds the representative full profile with an
+// explicit tun route-exclude list (as real subscriptions ship it).
+func profileWithTunRouteExcludes(excludes []any) map[string]any {
+	m := representativeFullProfile()
+	tun, _ := m["tun"].(map[string]any)
+	tun["route-exclude-address"] = excludes
+	return m
+}
+
+func runTunPipeline(t *testing.T, m map[string]any) map[string]any {
+	t.Helper()
+	if err := finalizeRuntimeConfigPipeline(m, t.TempDir(), 54333, 9097, "secret", "tun", true, true); err != nil {
+		t.Fatalf("pipeline error: %v", err)
+	}
+	return dnsMap(t, m)
+}
+
+func TestFakeIPRange6DroppedWhenTunRoutingExcludesIt(t *testing.T) {
+	withConnectionPrefs(t, ConnectionSettings{}) // IPv6 default ON
+	m := profileWithTunRouteExcludes([]any{
+		"224.0.0.0/3", "10.0.0.0/8", "127.0.0.0/8", "192.168.0.0/16",
+		"fc00::/7", "ff00::/8", "fe80::/10",
+	})
+	d := runTunPipeline(t, m)
+
+	if v, present := d["fake-ip-range6"]; present {
+		t.Errorf("fake-ip-range6 = %v, want it dropped: fc00::/7 is route-excluded, so the pool would be a black hole", v)
+	}
+	// The v4 pool and the master IPv6 switch must be untouched — real IPv6
+	// destinations still have to be captured by the tunnel (no leak).
+	if d["fake-ip-range"] != "198.18.0.1/16" {
+		t.Errorf("fake-ip-range = %v, want the v4 pool preserved", d["fake-ip-range"])
+	}
+	if m["ipv6"] != true || d["ipv6"] != true {
+		t.Errorf("ipv6 = %v / dns.ipv6 = %v, want both true", m["ipv6"], d["ipv6"])
+	}
+}
+
+func TestFakeIPRange6KeptWhenTunRoutesIt(t *testing.T) {
+	withConnectionPrefs(t, ConnectionSettings{})
+	// Same list minus the ULA exclusion: the pool is reachable, keep it.
+	m := profileWithTunRouteExcludes([]any{"10.0.0.0/8", "192.168.0.0/16", "ff00::/8", "fe80::/10"})
+	d := runTunPipeline(t, m)
+
+	if v, _ := d["fake-ip-range6"].(string); v == "" {
+		t.Errorf("fake-ip-range6 = %v, want the pool kept when nothing excludes it", d["fake-ip-range6"])
+	}
+}
+
+func TestFakeIPRange6FromSubscriptionAlsoDroppedWhenUnroutable(t *testing.T) {
+	withConnectionPrefs(t, ConnectionSettings{})
+	m := profileWithTunRouteExcludes([]any{"fc00::/7"})
+	dnsMap(t, m)["fake-ip-range6"] = "fdfe:1234::1/64" // the subscription's own pool
+	d := runTunPipeline(t, m)
+
+	if v, present := d["fake-ip-range6"]; present {
+		t.Errorf("fake-ip-range6 = %v, want a subscription-supplied pool dropped too when it is route-excluded", v)
+	}
+}
+
+func TestFakeIPRange6KeptWhenTunInet6AddressCoversIt(t *testing.T) {
+	withConnectionPrefs(t, ConnectionSettings{})
+	m := profileWithTunRouteExcludes([]any{"fc00::/7"})
+	m["tun"].(map[string]any)["inet6-address"] = []any{"fdfe:dcba:9876::1/64"}
+	d := runTunPipeline(t, m)
+
+	if v, _ := d["fake-ip-range6"].(string); v == "" {
+		t.Errorf("fake-ip-range6 = %v, want it kept: an on-link tun inet6-address makes the pool reachable", d["fake-ip-range6"])
+	}
+}
+
+func TestPrefixCovers(t *testing.T) {
+	mk := func(s string) netip.Prefix {
+		p, err := netip.ParsePrefix(s)
+		if err != nil {
+			t.Fatalf("bad prefix %q: %v", s, err)
+		}
+		return p.Masked()
+	}
+	cases := []struct {
+		outer, inner string
+		want         bool
+	}{
+		{"fc00::/7", "fdfe:dcba:9876::1/64", true},
+		{"fe80::/10", "fdfe:dcba:9876::1/64", false},
+		{"fdfe:dcba:9876::/64", "fdfe:dcba:9876::/64", true},
+		{"fdfe:dcba:9876::/126", "fdfe:dcba:9876::/64", false}, // narrower can't cover wider
+		{"10.0.0.0/8", "fdfe:dcba:9876::1/64", false},          // family mismatch
+		{"0.0.0.0/0", "198.18.0.0/16", true},
+	}
+	for _, c := range cases {
+		if got := prefixCovers(mk(c.outer), mk(c.inner)); got != c.want {
+			t.Errorf("prefixCovers(%s, %s) = %v, want %v", c.outer, c.inner, got, c.want)
+		}
+	}
+}
+
+// repairRuntimeConfigDNS is the last writer of config.yaml before the core reads
+// it, and its self-heal re-fills the v6 pool — so the guard must run there too or
+// the pipeline's decision is silently undone on disk.
+func TestRepairRuntimeConfigDNSKeepsTheGuardDecision(t *testing.T) {
+	withConnectionPrefs(t, ConnectionSettings{})
+	dir := t.TempDir()
+	cfgPath := filepath.Join(dir, "config.yaml")
+	written := `mixed-port: 7890
+mode: rule
+ipv6: true
+tun:
+  enable: true
+  stack: gvisor
+  auto-route: true
+  route-exclude-address:
+    - 192.168.0.0/16
+    - fc00::/7
+dns:
+  enable: true
+  listen: ":1053"
+  ipv6: true
+  enhanced-mode: fake-ip
+  fake-ip-range: 198.18.0.1/16
+  fake-ip-range6: fdfe:dcba:9876::1/64
+rules:
+  - MATCH,DIRECT
+`
+	if err := os.WriteFile(cfgPath, []byte(written), 0o644); err != nil {
+		t.Fatalf("write config: %v", err)
+	}
+	if err := repairRuntimeConfigDNS(cfgPath); err != nil {
+		t.Fatalf("repair: %v", err)
+	}
+	b, err := os.ReadFile(cfgPath)
+	if err != nil {
+		t.Fatalf("read back: %v", err)
+	}
+	var m map[string]any
+	if err := yaml.Unmarshal(b, &m); err != nil {
+		t.Fatalf("reparse: %v", err)
+	}
+	d, _ := m["dns"].(map[string]any)
+	if v, present := d["fake-ip-range6"]; present {
+		t.Errorf("fake-ip-range6 = %v on disk after repair, want it dropped (fc00::/7 is route-excluded)", v)
+	}
+	if d["fake-ip-range"] != "198.18.0.1/16" {
+		t.Errorf("fake-ip-range = %v, want the v4 pool preserved", d["fake-ip-range"])
+	}
+}

--- a/apps/sloth-clash-desktop/subscription_overlay.go
+++ b/apps/sloth-clash-desktop/subscription_overlay.go
@@ -139,6 +139,9 @@ func ensureDefaultDNSForTun(m map[string]any) {
 		// (clash-verge-rev #7373). Filled unconditionally so a profile that
 		// flips ipv6 on later is still correct. Empty string counts as missing
 		// so a hand-edited YAML gets repaired.
+		// The pool is only KEPT if the final tun block actually routes it —
+		// dropUnroutableFakeIPRange6 has the last word at the end of the
+		// pipeline (a black-holed pool stalls every dual-stack site).
 		if v, ok := dns["fake-ip-range6"].(string); !ok || strings.TrimSpace(v) == "" {
 			dns["fake-ip-range6"] = "fdfe:dcba:9876::1/64"
 		}
@@ -359,4 +362,5 @@ func overlaySlothRuntimeOnMap(m map[string]any, mixedPort, ctrlPort int, secret,
 	if enableTun {
 		applyCorpVpnOverlay(m, currentCorpVpnSplit())
 	}
+
 }

--- a/apps/sloth-clash-desktop/subscription_validate.go
+++ b/apps/sloth-clash-desktop/subscription_validate.go
@@ -185,6 +185,11 @@ func finalizeRuntimeConfigPipeline(
 	if err := validateFinalConfigSemantics(m); err != nil {
 		return err
 	}
+	// Last word on the fake-ip v6 pool: it may only survive if the final tun
+	// block actually routes it (see dropUnroutableFakeIPRange6). Deliberately
+	// after validation — validateDNSInvariants self-heals the DNS block, which
+	// re-injects the pool.
+	dropUnroutableFakeIPRange6(m)
 	overlayBundledGeoData(m, dataDir)
 	return nil
 }

--- a/scripts/prebuild.mjs
+++ b/scripts/prebuild.mjs
@@ -165,7 +165,7 @@ async function updateHashCache(targetPath) {
 // Pinned mihomo (Clash.Meta) core version — single source of truth.
 // To bump: edit this constant, then run `pnpm run prebuild --force` to refresh
 // the embedded sidecar. Override at build time with MIHOMO_CORE_VERSION (CI/testing).
-const META_VERSION_PINNED = 'v1.19.29'
+const META_VERSION_PINNED = 'v1.19.30'
 const META_URL_PREFIX = `https://github.com/MetaCubeX/mihomo/releases/download`
 let META_VERSION
 


### PR DESCRIPTION
## What

Two changes on the 0.9.2 line:

1. **Mihomo core -> v1.19.30** (`99d463f0`) — CVE-2026-56862 in the core's Go TLS stack, the TUN dns-hijack zero-filled/stale reply fix, plus new protocol surface (ZeroTier, AmneziaWG 3.0/3.1, `ip-stack`, H2C/QUICv2 sniffing). Locked with a passthrough test that runs the generated config through the shipped core.

2. **IPv6 fake-ip pool guard** (`416ac9ec`) — fixes the "everything is slower than it used to be" report.

## The bug

A profile whose tun block excludes `fc00::/7` (the common default, so the LAN's own ULA prefix stays direct) leaves our injected pool `fdfe:dcba:9876::1/64` unroutable: `auto-route` installs the IPv6 default split minus the exclusions, so every fake AAAA we hand out goes out of the physical NIC and dies there.

Measured on Windows 11 with a real profile:

| Probe | Result |
| --- | --- |
| `curl -4 https://fonts.googleapis.com` through TUN | 0.27 s |
| `curl -6` same URL | **21 s, connect never completes** |
| AAAA from our core | `fdfe:dcba:9876::112` |
| AAAA from the same core without `fake-ip-range6` | `ANCOUNT=0` (NODATA) |
| `Find-NetRoute fdfe:dcba:9876::112` | out of Ethernet, not the tunnel |
| Core log, connections to any `fdfe:` destination | none — packets never reached mihomo |

In a browser that is a Happy-Eyeballs stall on the IPv6 half of every dual-stack site, with nothing in the logs.

## The fix

Drop `dns.fake-ip-range6` when a `tun.route-exclude-address` prefix covers it, unless an explicit `tun.inet6-address` makes it on-link. Two call sites, both required:

- the pipeline, **after** validation (`validateDNSInvariants` self-heals the DNS block and would re-inject the pool);
- `repairRuntimeConfigDNS`, the last writer of `config.yaml` before the core reads it.

Top-level `ipv6` stays `true`, so the TUN keeps its v6 routes and real IPv6 is still captured — no leak is reintroduced.

Also: that same last-mile repair used to "heal" a non-mapping `dns:` node, replacing a broken section with defaults and hiding the parse error the core had already reported. It now leaves it alone so the `-t` preflight surfaces the real error.

## Tests

- 6 new tests in `fakeip_v6_route_guard_test.go`, including one that reads the file back off disk after `repairRuntimeConfigDNS`.
- `go test ./...` green; `pnpm run test:required` green.
- Required gate re-run with `SLOTH_MIHOMO_BIN` set: green, including `TestIntegrationPreflightWithRealCoreBinary` (which failed before this branch whenever a core binary was available).
